### PR TITLE
Added new "CREATE" event

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -80,7 +80,7 @@ class Settings extends Watcher {
     /**
      * Internal created event handler.
      *
-     * @see _handleChange
+     * @see _handleCreate
      * @type {Function}
      * @private
      */

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -78,6 +78,15 @@ class Settings extends Watcher {
     this._configFilePath = null;
 
     /**
+     * Internal created event handler.
+     *
+     * @see _handleChange
+     * @type {Function}
+     * @private
+     */
+    this._onCreate = this._handleCreate.bind(this);
+
+    /**
      * Internal change event handler.
      *
      * @see _handleChange
@@ -171,6 +180,7 @@ class Settings extends Watcher {
       debug('no config file found at ' + configFilePath);
 
       fs.outputJsonSync(configFilePath, {});
+      this._emitCreateEvent();
 
       debug('config file generated at ' + configFilePath);
     }
@@ -200,9 +210,19 @@ class Settings extends Watcher {
    * @private
    */
   _setupInternalEventBindings() {
+    this.on(Settings.Events.CREATE, this._onCreated);
     this.on(Settings.Events.CHANGE, this._onChange);
     this.on(Settings.Events.SAVE, this._onSave);
     this.on(Settings.Events.ERROR, this._onError);
+  }
+
+  /**
+   * Called when the "created" event fires.
+   *
+   * @private
+   */
+  _handleCreate() {
+    debug('settings file created');
   }
 
   /**
@@ -534,6 +554,16 @@ class Settings extends Watcher {
   }
 
   /**
+   * Triggers the "created" event.
+   *
+   * @emits ElectronSettings#save
+   * @private
+   */
+  _emitCreateEvent() {
+    this.emit(Settings.Events.CREATE);
+  }
+
+  /**
    * Triggers the "change" event.
    *
    * @emits ElectronSettings#change
@@ -574,6 +604,7 @@ class Settings extends Watcher {
   _destroy() {
     this._debouncedSave.cancel();
 
+    this.removeListener(Settings.Events.CREATE, this._onCreate);
     this.removeListener(Settings.Events.CHANGE, this._onChange);
     this.removeListener(Settings.Events.SAVE, this._onSave);
     this.removeListener(Settings.Events.ERROR, this._onError);
@@ -583,6 +614,7 @@ class Settings extends Watcher {
     this._settingsCache = null;
     this._options = null;
     this._debouncedSave = null;
+    this._onCreate = null;
     this._onChange = null;
     this._onError = null;
     this._onSave = null;
@@ -619,6 +651,7 @@ Settings.DefaultOptions = {
  * @readonly
  */
 Settings.Events = {
+  CREATE: 'create',
   CHANGE: 'change',
   ERROR: 'error',
   SAVE: 'save'

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "manager",
     "user"
   ],
-  "repository": "https://github.com/nathanbuchar/electron-settings",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nathanbuchar/electron-settings"
+  },
   "author": "Nathan Buchar <hello@nathanbuchar.com>",
   "license": "ISC",
   "dependencies": {


### PR DESCRIPTION
This pull request adds a new "CREATE" event which is emitted whenever the config file has been successfully created. It makes it particularly easy to e.g. set default values whenever a new config file has been created.