### PR TITLE
Added docs for new `create` event

### DIFF
--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -4,6 +4,7 @@ Events
 * [`change`][event_change]
 * [`error`][event_error]
 * [`save`][event_save]
+* [`create`][event_create]
 
 
 
@@ -82,6 +83,28 @@ settings.on('save', handleSave);
 ```
 
 
+***
+
+
+create
+-----
+
+**`settings.on('create', handler)`**
+
+Called when the settings file has been create on disk, e.g. on first run.
+
+
+**Example**
+
+```js
+function handleCreate() {
+  console.log('Settings file created');
+}
+
+settings.on('create', handleCreate);
+```
+
+
 
 
 
@@ -91,3 +114,4 @@ settings.on('save', handleSave);
 [event_change]: #change
 [event_error]: #error
 [event_save]: #save
+[event_create]: #create


### PR DESCRIPTION
This is the follow up PR for #14 that includes the docs of the newly created `create` event.