### PR TITLE
Fix _setupInternalEventBindings() in 1.1.0

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -210,7 +210,7 @@ class Settings extends Watcher {
    * @private
    */
   _setupInternalEventBindings() {
-    this.on(Settings.Events.CREATE, this._onCreated);
+    this.on(Settings.Events.CREATE, this._onCreate);
     this.on(Settings.Events.CHANGE, this._onChange);
     this.on(Settings.Events.SAVE, this._onSave);
     this.on(Settings.Events.ERROR, this._onError);


### PR DESCRIPTION
Fixes the latest release on NPM (1.1.0) and the unit tests are passing again.
