### PR TITLE
Issue #23 - bools

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -456,12 +456,12 @@ class Settings extends Watcher {
         diff.item.action = Settings.ChangeActionsMap[difference.kind];
 
         // Rewrite `lhs` to `item.was`, if it exists.
-        if (difference.lhs) {
+        if (difference.lhs !== undefined) {
           diff.item.was = difference.lhs;
         }
 
         // Rewrite `rhs` to `item.now`, if it exists.
-        if (difference.rhs) {
+        if (difference.rhs !== undefined) {
           diff.item.now = difference.rhs;
         }
       } else if (diff.action === Settings.ChangeActions.ARRAY) {
@@ -473,24 +473,24 @@ class Settings extends Watcher {
         diff.item.action = Settings.ChangeActionsMap[difference.item.kind];
 
         // Rewrite `item.lhs` to `item.was`, if it exists.difference
-        if (difference.item.lhs) {
+        if (difference.item.lhs !== undefined) {
           diff.item.was = difference.item.lhs;
         }
 
         // Rewrite `item.rhs` to `item.now`, if it exists.
-        if (difference.item.rhs) {
+        if (difference.item.rhs !== undefined) {
           diff.item.now = difference.item.rhs;
         }
       } else {
         diff.keyPath = difference.path.join('.');
 
         // Rewrite `lhs` to `was`, if it exists.
-        if (difference.lhs) {
+        if (difference.lhs !== undefined) {
           diff.was = difference.lhs;
         }
 
         // Rewrite `rhs` to `now`, if it exists.
-        if (difference.rhs) {
+        if (difference.rhs !== undefined) {
           diff.now = difference.rhs;
         }
       }

--- a/test/spec.js
+++ b/test/spec.js
@@ -318,6 +318,59 @@ describe('watch', function () {
     settings.unset(keyPath);
   });
 
+  it('should handle NEW NULL values', function (done) {
+    let keyPath = 'foo';
+    let value = null;
+
+    settings.watch(keyPath, data => {
+      should.exist(data);
+      expect(data.action).to.equal(ElectronSettings.ChangeActions.NEW);
+      expect(data.keyPath).to.equal(keyPath);
+      expect(data.now).to.equal(value);
+      done();
+    });
+
+    settings.set(keyPath, value);
+  });
+
+  it('should handle EDITED NULL values', function (done) {
+    let keyPath = 'foo';
+    let values = {
+      before: false,
+      after: null
+    };
+
+    settings.set(keyPath, values.before);
+
+    settings.watch(keyPath, data => {
+      should.exist(data);
+      expect(data.action).to.equal(ElectronSettings.ChangeActions.EDITED);
+      expect(data.keyPath).to.equal(keyPath);
+      expect(data.was).to.equal(values.before);
+      expect(data.now).to.equal(values.after);
+      done();
+    });
+
+    settings.set(keyPath, values.after);
+  });
+
+  it('should handle DELETED NULL values', function (done) {
+    let keyPath = 'foo';
+    let value = null;
+
+    settings.set(keyPath, value);
+
+    settings.watch(keyPath, data => {
+      should.exist(data);
+      expect(data.action).to.equal(ElectronSettings.ChangeActions.DELETED);
+      expect(data.keyPath).to.equal(keyPath);
+      expect(data.was).to.equal(value);
+      done();
+    });
+
+    settings.unset(keyPath);
+  });
+
   it('should handle NEW ARRAY values', function (done) {
     let keyPath = 'foo';
     let values = {

--- a/test/spec.js
+++ b/test/spec.js
@@ -212,7 +212,7 @@ describe('getConfigFilePath()', function () {
 
 describe('watch', function () {
 
-  it('should handle NEW values', function (done) {
+  it('should handle NEW STRING values', function (done) {
     let keyPath = 'foo';
     let value = 'bar';
 
@@ -227,7 +227,7 @@ describe('watch', function () {
     settings.set(keyPath, value);
   });
 
-  it('should handle EDITED values', function (done) {
+  it('should handle EDITED STRING values', function (done) {
     let keyPath = 'foo';
     let values = {
       before: 'bar',
@@ -248,9 +248,62 @@ describe('watch', function () {
     settings.set(keyPath, values.after);
   });
 
-  it('should handle DELETED values', function (done) {
+  it('should handle DELETED STRING values', function (done) {
     let keyPath = 'foo';
     let value = 'bar';
+
+    settings.set(keyPath, value);
+
+    settings.watch(keyPath, data => {
+      should.exist(data);
+      expect(data.action).to.equal(ElectronSettings.ChangeActions.DELETED);
+      expect(data.keyPath).to.equal(keyPath);
+      expect(data.was).to.equal(value);
+      done();
+    });
+
+    settings.unset(keyPath);
+  });
+
+  it('should handle NEW BOOL values', function (done) {
+    let keyPath = 'foo';
+    let value = false;
+
+    settings.watch(keyPath, data => {
+      should.exist(data);
+      expect(data.action).to.equal(ElectronSettings.ChangeActions.NEW);
+      expect(data.keyPath).to.equal(keyPath);
+      expect(data.now).to.equal(value);
+      done();
+    });
+
+    settings.set(keyPath, value);
+  });
+
+  it('should handle EDITED BOOL values', function (done) {
+    let keyPath = 'foo';
+    let values = {
+      before: false,
+      after: true
+    };
+
+    settings.set(keyPath, values.before);
+
+    settings.watch(keyPath, data => {
+      should.exist(data);
+      expect(data.action).to.equal(ElectronSettings.ChangeActions.EDITED);
+      expect(data.keyPath).to.equal(keyPath);
+      expect(data.was).to.equal(values.before);
+      expect(data.now).to.equal(values.after);
+      done();
+    });
+
+    settings.set(keyPath, values.after);
+  });
+
+  it('should handle DELETED BOOL values', function (done) {
+    let keyPath = 'foo';
+    let value = false;
 
     settings.set(keyPath, value);
 


### PR DESCRIPTION
Upon closer thought, I decided `typeof thingy !== "undefined" && thingy !== null` was too strict, and `thingy !== undefined` would suffice because

1. Since they are all properties, there's no need to worry about ReferenceError (which is the primary reason to use `typeof`)
2. It might actually be desirable to allow settings to have `null` values.

So here you go!