### PR TITLE
Add defaults and atomic saving support, remove crash on malformed settings file

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Usage
 
   * `options.debouncedSaveTime` *(number)* - The maximum amount of time in milliseconds that must elapse before saving to disk. Default `100`
 
+  * `options.defaultsConfigPath` *(string)* - Absolute path to default settings, which will be used when a given user attribute is undefined.
+
+  * `options.atomicSaving` *(boolean)* - Recommended, however false by default. Performs saves atomically to ensure data-write consistency. When enabled, saves are performed synchronously rather than asynchronously, so may have adverse performance effect if your settings data file is large.
+
 
 **Example**
 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -126,8 +126,8 @@ class Settings extends Watcher {
     this._setupOptions(options);
     this._setupSaveDebouncer();
     this._setupConfigFile();
-    this._setupInternalCache();
     this._setupInternalEventBindings();
+    this._setupInternalCache();
   }
 
   /**
@@ -200,7 +200,16 @@ class Settings extends Watcher {
     try {
       this._settingsCache = JSON.parse(contents);
     } catch (err) {
-      throw new Error('malformed settings data at ' + this._configFilePath);
+      debug('re-generating malformed config file found at ' + this._configFilePath);
+
+      err = new Error('Malformed settings data at ' + path.basename(this._configFilePath));
+      this._emitErrorEvent(err);
+
+      this._settingsCache = {};
+      fs.outputJsonSync(this._configFilePath, this._settingsCache);
+      this._emitCreateEvent();
+
+      debug('config file re-generated at ' + this._configFilePath);
     }
   }
 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -51,6 +51,15 @@ class Settings extends Watcher {
     this._settingsCache = null;
 
     /**
+    * Internal cache of the defaults object.
+    *
+    * @type Object
+    * @default null
+    * @private
+    */
+    this._defaultsCache = null;
+
+    /**
     * Settings instance options.
     *
     * @type Object
@@ -211,6 +220,30 @@ class Settings extends Watcher {
 
       debug('config file re-generated at ' + this._configFilePath);
     }
+    
+    this._defaultsCache = this._loadDefaultConfig();
+  }
+
+  /**
+   * Reads the default settings file, if passed in options and existing
+   *
+   * @private
+   */
+  _loadDefaultConfig() {
+    let defaultsConfigPath = this._options.defaultsConfigPath;
+    if (!defaultsConfigPath || !defaultsConfigPath.length) {
+      debug('default config file not specified');
+      return null;
+    }
+
+    try {
+      let contents = fs.readFileSync(defaultsConfigPath);
+      var defaultSettings = JSON.parse(contents);
+    } catch (err) {
+      debug('failed to read default config: ' + err);
+    }
+
+    return defaultSettings;
   }
 
   /**
@@ -314,9 +347,15 @@ class Settings extends Watcher {
    */
   _get(keyPath) {
     if (_.isUndefined(keyPath) || keyPath === '.') {
+      return Object.assign(this._defaultsCache || {}, this._settingsCache);
+    } else if (keyPath === '..') {
       return this._settingsCache;
     } else if (keyPathHelpers.hasKeyPath(keyPath)) {
-      return keyPathHelpers.getValueAtKeyPath(this._settingsCache, keyPath);
+      var result = keyPathHelpers.getValueAtKeyPath(this._settingsCache, keyPath);
+      if(result === undefined && this._defaultsCache) {
+        result = keyPathHelpers.getValueAtKeyPath(this._defaultsCache, keyPath);
+      }
+      return result;
     }
   }
 
@@ -620,6 +659,7 @@ class Settings extends Watcher {
 
     this.removeAllListeners();
 
+    this._defaultsCache = null;
     this._settingsCache = null;
     this._options = null;
     this._debouncedSave = null;
@@ -640,7 +680,8 @@ class Settings extends Watcher {
 Settings.Defaults = {
   configDirPath: null,
   configFileName: 'settings',
-  debouncedSaveTime: 100
+  debouncedSaveTime: 100,
+  defaultsConfigPath: null
 };
 
 /**

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -327,15 +327,30 @@ class Settings extends Watcher {
   _save() {
     debug('saving settings to disk...');
 
-    fs.writeJson(this._configFilePath, this._settingsCache, err => {
-      if (err) {
-        let err = new Error('Failed to save ' + path.basename(this._configFilePath));
+    let atomicSaving = this._options.atomicSaving;
+    if (atomicSaving) {
+      let tmpfile = this._configFilePath + '.tmp';
+      try {
+        fs.outputJsonSync(tmpfile, this._settingsCache);
+        fs.renameSync(tmpfile, this._configFilePath);
+      } catch (err) {
+        try {
+          fs.unlinkSync(tmpfile);
+        } catch (e) { }
 
+        let err = new Error('Failed to save ' + path.basename(this._configFilePath));
         return this._emitErrorEvent(err);
       }
+    } else {
+      fs.writeJson(this._configFilePath, this._settingsCache, err => {
+        if (err) {
+          let err = new Error('Failed to save ' + path.basename(this._configFilePath));
+          return this._emitErrorEvent(err);
+        }
 
-      this._emitSaveEvent();
-    });
+        this._emitSaveEvent();
+      });
+    }
   }
 
   /**
@@ -681,7 +696,8 @@ Settings.Defaults = {
   configDirPath: null,
   configFileName: 'settings',
   debouncedSaveTime: 100,
-  defaultsConfigPath: null
+  defaultsConfigPath: null,
+  atomicSaving: false
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-settings",
-  "version": "1.1.1",
+  "version": "1.2.1",
   "description": "User settings manager for Electron",
   "main": "index.js",
   "scripts": {
@@ -26,6 +26,11 @@
     {
       "name": "Kai Eichinger",
       "email": "kai.eichinger@outlook.com"
+    },
+    {
+      "name": "Jeff Bargmann",
+      "email": "jeffbargmann@gmail.com",
+      "web": "https://twitter.com/jeffbargmann"
     }
   ],
   "license": "ISC",


### PR DESCRIPTION
Hi Nathan thanks for your work!

Looks like v1 is dead and v2's in the works. But anyhow, we're using v1 for now :)
Non-atomic saving = corrupt settings opportunity = crashes on startup, it turns out. Solved from a couple angles.

Added a defaults notion as well.  I notice v2 has a defaults object option as well. Few thoughts
- Consider passing filename instead of in-memory object? Seems more conventional to keep settings out of app code itself, adjustable by non-programmers etc.
- Consider what happens when app is updated, new settings / new defaults are added? Current system will only apply defaults once, so new settings will not have their defaults populated.
- Consider separating the idea of defaults & settings. My initial implementation used Object.assign/extend as does yours to merge the defaults in with the users' settings upon each load. This however locks in the settings as if they're the users' own. This can be desirable in some cases (i.e. if you change certain default behaviors, users might be surprised), but bad in others (any setting that should always follow default, except for when overridden).

Thanks!