### PR TITLE
v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,32 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ***
 
+2.1.0 - Aug. 2, 2016
+--------------------
+* Adds `defaults()`.
+* Adds `applyDefaults()` and `applyDefaultsSync()`.
+* Adds `resetToDefaults()` and `resetToDefaultsSync()`.
+* Adds `util.assert` for parameter checks.
+* Removes `reset()` and `resetSync()` (breaking).
+* Removes the option to omit the key path in `set()` and `setSync()`. A key path is now required (breaking).
+* Removes the option to specify default settings via `configure()`.
+* Fixes initial settings creation. Before it wouldn't apply default settings.
+* Fixes Changelog.
+* Updates Readme.
+
 2.0.2 - Jul. 31, 2016
 ---------------------
 * Fixes documentation links.
 * Fixes Changelog.
 
-2.0.1 - Jul. 21, 2016
+2.0.1 - Jul. 31, 2016
 ---------------------
 * Fixes documentation links.
 * Updates Changelog.
 * Updates .npmignore.
 * Removes .github folder.
 
-2.0.0 - Jul. 21, 2016
+2.0.0 - Jul. 31, 2016
 ---------------------
 * Adds `has()` method.
 * Adds `configure()` method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Adds `applyDefaults()` and `applyDefaultsSync()`.
 * Adds `resetToDefaults()` and `resetToDefaultsSync()`.
 * Adds `util.assert` for parameter checks.
+* Adds support for resetting the settings file if malformed JSON data is encountered.
 * Removes `reset()` and `resetSync()` (breaking).
 * Removes the option to omit the key path in `set()` and `setSync()`. A key path is now required (breaking).
 * Removes the option to specify default settings via `configure()`.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ electron-settings
 
 A simple persistent user settings manager for [Electron][external_electron]. Originally adapted from [Atom's own configuration manager][external_atom-config], electron-settings allows you to save user settings to the disk so that they can be loaded in the next time your app starts.
 
-Also, you can [observe key paths][method_observe] and get notified if their values change. So that's pretty neat.
+Also, you can [observe key paths][method_observe] and get notified if their value changes. So that's pretty neat.
 
 **Note:** v2 is not compatible with earlier versions of electron-settings.
 
@@ -36,28 +36,34 @@ settings.set('name', {
   first: 'Cosmo',
   last: 'Kramer'
 }).then(() => {
-  settings.getSync('name.first');
-  // => "Cosmo"
+  settings.get('name.first').then(val => {
+    // => "Cosmo"
+  });
 });
 
 settings.getSettingsFilePath();
 // => /Users/You/Library/Application Support/YourApp/Settings
 ```
 
-Key Path Observers
-------------------
-electron-settings allows you to subscribe to key paths and get notified if their value changes. For more information and examples, take a look at [the docs][method_observe].
+
+Default Settings
+----------------
+
+You can configure default settings by using [`settings.defaults()`][method_defaults]. This will set the defaults object globally. If this is the first time the settings file is being accessed, the defaults will be applied automatically.
 
 ```js
-settings.setSync('foo.bar', 'baz');
-
-settings.observe('foo.bar', evt => {
-  console.log(evt.oldValue); // => 'baz'
-  console.log(evt.newValue); // => 'qux'
+settings.defaults({
+  foo: 'bar'
 });
 
-settings.setSync('foo.bar', 'qux');
+settings.get('foo').then(val => {
+  // => 'bar'
+});
 ```
+
+Additionally, you can use [`applyDefaults()`][method_apply-defaults] or [`resetToDefaults()`][method_reset-to-defaults] to fit your needs.
+
+
 
 FAQ
 ---
@@ -76,6 +82,16 @@ FAQ
   }
   ```
 
+* **Where is the settings file saved?**
+
+  The settings file is named `Settings` and is saved in your app's [user data directory](http://electron.atom.io/docs/api/app/#appgetpathname):
+
+    * `~/Library/Application Support/YourApp` on MacOS.
+    * `%APPDATA%/YourApp` on Windows.
+    * `$XDG_CONFIG_HOME/YourApp` or `~/.config/YourApp` on Linux.
+
+  You can use [`getSettingsFilePath()`][method_get-settings-file-path] to get the full path to the settings file.
+
 * **Can I use electron-settings in both the main and renderer processes?**
 
   Yes! Just be aware that if the window closes during an async operation, data may be lost.
@@ -88,15 +104,10 @@ FAQ
 
   electron-settings reads and writes to the file system asynchronously. In order to ensure data integrity, you should use promises. Alternatively, all methods have a synchronous counterpart that you may use instead.
 
-* **Where is the settings file saved?**
 
-  The settings file is named `Settings` and is saved in your app's [user data directory](http://electron.atom.io/docs/api/app/#appgetpathname):
 
-    * `~/Library/Application Support/YourApp` on MacOS.
-    * `%APPDATA%/YourApp` on Windows.
-    * `$XDG_CONFIG_HOME/YourApp` or `~/.config/YourApp` on Linux.
+***
 
-  You can use [`getSettingsFilePath()`][method_getSettingsFilePath] to get the full path to the settings file.
 
 
 Documentation
@@ -118,7 +129,7 @@ License
 
 
 ***
-<small>Last updated **Jul. 31st, 2016** by [Nathan Buchar].</small>
+<small>Last updated **Aug. 2nd, 2016** by [Nathan Buchar].</small>
 
 <small>**Having trouble?** [Get help on Gitter][external_gitter].</small>
 
@@ -133,6 +144,7 @@ License
 
 [section_install]: #install
 [section_quick-start]: #quick-start
+[section_default-settings]: #default-settings
 [section_faq]: #faq
 [section_documentation]: #documentation
 [section_contributors]: #contributors
@@ -141,8 +153,10 @@ License
 [docs_events]: ./docs/events.md
 [docs_methods]: ./docs/methods.md
 
-[method_observe]: ./docs/methods.md#observe
-[method_getSettingsFilePath]: ./docs/methods.md#getsettingsfilepath
+[method_get-settings-file-path]: ./docs/methods.md#getsettingsfilepath
+[method_defaults]: ./docs/methods.md#defaults
+[method_apply-defaults]: ./docs/methods.md#applydefaults
+[method_reset-to-defaults]: ./docs/methods.md#resettodefaults
 
 [external_electron]: https://electron.atom.com
 [external_atom-config]: https://github.com/atom/atom/blob/master/src/config.coffee

--- a/docs/methods.md
+++ b/docs/methods.md
@@ -7,16 +7,161 @@
 Methods
 =======
 
+* [`configure()`][method_configure]
+* [`defaults()`][method_defaults]
+* [`observe()`][method_observe]
+* [`getSettingsFilePath()`][method_get-settings-file-path]
+
+
 * [`has()`][method_has] [*sync*][method_has-sync]
 * [`get()`][method_get] [*sync*][method_get-sync]
 * [`set()`][method_set] [*sync*][method_set-sync]
 * [`delete()`][method_delete] [*sync*][method_delete-sync]
-* [`reset()`][method_reset] [*sync*][method_reset-sync]
 * [`clear()`][method_clear] [*sync*][method_clear-sync]
-* [`observe()`][method_observe]
-* [`configure()`][method_configure]
-* [`getSettingsFilePath()`][method_getSettingsFilePath]
+* [`applyDefaults()`][method_apply-defaults] [*sync*][method_apply-defaults-sync]
+* [`resetToDefaults()`][method_reset-to-defaults] [*sync*][method_reset-to-defaults-sync]
 
+
+
+***
+
+
+configure()
+-----------
+
+**`settings.configure(options)`**
+
+Globally configures default options.
+
+**Arguments**
+
+* **`options`** *Object*
+  * `atomicSaving` *Boolean* (optional) - Whether electron-settings should create a tmp file during save to ensure data-write consistency. Defaults to `true`.
+  * `prettify` *Boolean* (optional) - Prettify the JSON output. Defaults to `false`.
+
+
+**Examples**
+
+Always prettify output unless otherwise stated.
+```js
+settings.configure({
+  prettify: true
+});
+
+// Output will be prettified.
+settings.setSync('foo', 'bar');
+
+// Output will not be prettified.
+settings.setSync('foo', 'bar', { prettify: false });
+```
+
+
+***
+
+
+defaults()
+----------
+
+**`settings.defaults(defaults)`**
+
+Globally configures default settings.
+
+If the settings file has not been created yet, these defaults will be applied, but only if `settings.defaults` is called *before* making any other calls that interact with the file system, such as `has()`, `get()`, or `set()`.
+
+**Arguments**
+  * **`defaults`** *Object* - The defaults object.
+
+**Examples**
+
+Set default settings for when the settings file is created for the first time.
+```js
+settings.defaults({
+  name: {
+    first: 'Joe',
+    last: 'Defacto'
+  }
+});
+
+settings.get('name.first').then(val => {
+  // => Joe
+});
+```
+
+
+***
+
+
+observe()
+---------
+
+**`settings.observe(keyPath, handler):Function`**
+
+Observes the chosen key path for changes and calls the handler if the value changes. Returns an Observer instance which has a `dispose` method. To unsubscribe, simply call `dispose()` on the returned key path observer.
+
+**Arguments**
+
+  * **`keyPath`** *String* - The path to the key that we wish to observe.
+  * **`handler`** *Function* - The callback that will be invoked if the value at the chosen key path changes. Returns:
+    * `evt` *Object*
+      * `oldValue` *Any*
+      * `newValue` *Any*
+
+**Examples**
+
+Given:
+```json
+{
+  "foo": "bar"
+}
+```
+
+Observe `"foo"`.
+```js
+settings.observe('foo' evt => {
+  // => {
+  //   oldValue: 'bar',
+  //   newValue: 'qux'
+  // }
+});
+
+settings.set('foo', 'qux');
+```
+
+Dispose the key path observer.
+```js
+const observer = settings.observe('foo' evt => {
+  // => {
+  //   oldValue: 'bar',
+  //   newValue: 'qux'
+  // }
+});
+
+settings.set('foo', 'qux').then(() => {
+  observer.dispose();
+});
+```
+
+
+***
+
+
+getSettingsFilePath()
+------------------------
+
+**`settings.getSettingsFilePath():string`**
+
+Returns the path to the config file. Typically found in your application's [user data directory](http://electron.atom.io/docs/api/app/#appgetpathname):
+
+  * `~/Library/Application Support/YourApp` on MacOS.
+  * `%APPDATA%/YourApp` on Windows.
+  * `$XDG_CONFIG_HOME/YourApp` or `~/.config/YourApp` on Linux.
+
+**Examples**
+
+```js
+settings.getSettingsFilePath();
+// => /Users/You/Library/Application Support/YourApp/Settings
+```
 
 
 ***
@@ -47,7 +192,6 @@ Given:
 Check if `"foo.bar"` exists.
 ```js
 settings.has('foo.bar').then(exists => {
-  console.log(exists);
   // => true
 });
 ```
@@ -55,7 +199,6 @@ settings.has('foo.bar').then(exists => {
 Check if `"grizzknuckle"` exists.
 ```js
 settings.has('grizzknuckle').then(exists => {
-  console.log(exists);
   // => false
 });
 ```
@@ -123,7 +266,6 @@ Given:
 Get all settings.
 ```js
 settings.get().then(value => {
-  console.log(value);
   // => { foo: { bar: 'baz' } }
 });
 ```
@@ -131,7 +273,6 @@ settings.get().then(value => {
 Get the value at `"foo.bar"`.
 ```js
 settings.get('foo.bar').then(value => {
-  console.log(value);
   // => 'baz'
 });
 ```
@@ -139,7 +280,6 @@ settings.get('foo.bar').then(value => {
 Get the value at `"snap"`.
 ```js
 settings.get('snap').then(value => {
-  console.log(value);
   // => undefined
 });
 ```
@@ -189,13 +329,13 @@ settings.getSync('snap');
 set()
 -----
 
-**`settings.set([keyPath, ]value[, options]):Promise`**
+**`settings.set(keyPath, value[, options]):Promise`**
 
-Sets the value of the key at the chosen key path. If no key path is provided, this will set the value of the entire settings object instead, but `value` must be an object. For synchronous operation, use [`setSync()`][method_set-sync].
+Sets the value of the key at the chosen key path. For synchronous operation, use [`setSync()`][method_set-sync].
 
 **Arguments**
 
-  * **`keyPath`** *String* (optional) - The path to the key whose value we wish to set. This key need not already exist.
+  * **`keyPath`** *String* - The path to the key whose value we wish to set. This key need not already exist.
   * **`value`** *Any* - The value to set the key at the chosen key path to. This must be a data type supported by JSON: object, array, string, number, boolean, or `null`.
   * **`options`** *Object* (optional)
     * `atomicSaving` *Boolean* (optional) - Whether electron-settings should create a tmp file during save to ensure data-write consistency. Defaults to `true`.
@@ -215,22 +355,7 @@ settings.set('user.name', {
   last: 'Kramer'
 }).then(() => {
   settings.get('user.name.first').then(value => {
-    console.log(value);
     // => 'Cosmo'
-  });
-});
-```
-
-Set the value of the entire settings object.
-```js
-settings.set({
-  foo: {
-    bar: 'baz'
-  }
-}).then(() => {
-  settings.get(value => {
-    console.log(value);
-    // => { foo: { bar: 'baz' } }
   });
 });
 ```
@@ -242,7 +367,7 @@ settings.set({
 setSync()
 ---------
 
-**`settings.setSync([keyPath, ]value[, options])`**
+**`settings.setSync(keyPath, value[, options])`**
 
 The synchronous version of [`set()`][method_set].
 
@@ -264,18 +389,6 @@ settings.getSync('user.name.first');
 // => 'Cosmo'
 ```
 
-Set the value of the entire settings object.
-```js
-settings.setSync({
-  foo: {
-    bar: 'baz'
-  }
-});
-
-settings.getSync();
-// => { foo: { bar: 'baz' } }
-```
-
 
 ***
 
@@ -294,7 +407,7 @@ Deletes the key and value at the chosen key path. To clear the entire settings o
     * `atomicSaving` *Boolean* (optional) - Whether electron-settings should create a tmp file during save to ensure data-write consistency. Defaults to `true`.
     * `prettify` *Boolean* (optional) - Prettify the JSON output. Defaults to `false`.
 
-**Example**
+**Examples**
 
 Given:
 ```json
@@ -323,132 +436,7 @@ deleteSync()
 
 **`settings.deleteSync(keyPath[, options])`**
 
-The asynchronous version of [`delete()`][method_delete].
-
-**Example**
-
-Given:
-```json
-{
-  "foo": {
-    "bar": "baz"
-  }
-}
-```
-
-Delete `"foo.bar"`.
-```js
-settings.deleteSync('foo.bar');
-
-settings.getSync('foo');
-// => { foo: {} }
-```
-
-
-***
-
-
-reset()
--------
-
-**`settings.reset([keyPath, ][options]):Promise`**
-
-Resets the chosen key path to its default value provided in `options.defaults`. If no key path is given, this will reset the entire settings object to defaults. You can configure global defaults using [`configure()`][method_configure]. For synchronous operation, use [`resetSync()`][method_reset-sync].
-
-**Arguments**
-
-  * **`keyPath`** *String* (optional) - The path to the key that we wish to reset the value of.
-  * **`options`** *Object* (optional)
-    * `atomicSaving` *Boolean* (optional) - Whether electron-settings should create a tmp file during save to ensure data-write consistency. Defaults to `true`.
-    * `prettify` *Boolean* (optional) - Prettify the JSON output. Defaults to `false`.
-    * `defaults` *Object* (optional) - Default settings. Defaults to `{}`.
-
-**Example**
-
-Given:
-```json
-{
-  "foo": "qux"
-}
-```
-
-Reset `"foo"` to its default value.
-```js
-settings.reset('foo', {
-  defaults: {
-    {
-      "foo": "bar"
-    }
-  }
-}).then(() => {
-  settings.get().then(value => {
-    // => { foo: 'bar' }
-  });
-});
-```
-
-Configure global defaults and reset all settings to defaults.
-```js
-settings.configure({
-  defaults: {
-    foo: 'bar'
-  }
-});
-
-settings.reset().then(() => {
-  settings.get().then(value => {
-    // => { foo: 'bar' }
-  });
-});
-```
-
-
-***
-
-
-resetSync()
------------
-
-**`settings.resetSync([keyPath, ][options])`**
-
-The asynchronous version of [`reset()`][method_reset].
-
-**Example**
-
-Given:
-```json
-{
-  "foo": "qux"
-}
-```
-
-Reset `"foo"` to its default value.
-```js
-settings.resetSync('foo', {
-  defaults: {
-    {
-      "foo": "bar"
-    }
-  }
-});
-
-settings.getSync();
-// => { foo: 'bar' }
-```
-
-Configure global defaults and reset all settings to defaults.
-```js
-settings.configure({
-  defaults: {
-    foo: 'bar'
-  }
-});
-
-settings.resetSync();
-
-settings.getSync();
-// => { foo: 'bar' }
-```
+The synchronous version of [`delete()`][method_delete].
 
 
 ***
@@ -467,7 +455,7 @@ Clears the entire settings object. For synchronous operation, use [`clearSync()`
     * `atomicSaving` *Boolean* (optional) - Whether electron-settings should create a tmp file during save to ensure data-write consistency. Defaults to `true`.
     * `prettify` *Boolean* (optional) - Prettify the JSON output. Defaults to `false`.
 
-**Example**
+**Examples**
 
 Given:
 ```json
@@ -482,7 +470,6 @@ Clear all settings.
 ```js
 settings.clear(() => {
   settings.get(value => {
-    console.log(value);
     // => {}
   });
 });
@@ -499,130 +486,164 @@ clearSync()
 
 The asynchronous verison of [`clear()`][method_clear].
 
-**Example**
-
-Given:
-```json
-{
-  "foo": {
-    "bar": "baz"
-  }
-}
-```
-
-Clear all settings.
-```js
-settings.clearSync();
-
-settings.getSync();
-// => {}
-```
-
 
 ***
 
 
-configure()
------------
+applyDefaults()
+---------------
 
-**`settings.configure(options)`**
+**`settings.applyDefaults([options]):Promise`**
 
-Globally configures electron-settings options.
-
-**Arguments**
-
-* **`options`** *Object*
-  * `atomicSaving` *Boolean* (optional) - Whether electron-settings should create a tmp file during save to ensure data-write consistency. Defaults to `true`.
-  * `prettify` *Boolean* (optional) - Prettify the JSON output. Defaults to `false`.
-  * `defaults` *Object* (optional) - Default settings. Applies to [`reset()`][method_reset] and [`resetSync()`][method_reset-sync]. Defaults to `{}`.
-
-
-**Example**
-
-Always prettify output unless otherwise stated.
-```js
-settings.configure({
-  prettify: true
-});
-
-// Output will be prettified.
-settings.setSync('foo', 'bar');
-
-// Output will not be prettified.
-settings.setSync('foo', 'bar', { prettify: false });
-```
-
-***
-
-
-observe()
----------
-
-**`settings.observe(keyPath, handler):Function`**
-
-Observes the chosen key path for changes and calls the handler if the value changes. Returns an Observer instance which has a `dispose` method. To unsubscribe, simply call `dispose()` on the returned key path observer.
+Applies defaults to the current settings object (deep). Settings that already exist will not be overwritten, but keys that exist within the defaults that don't exist within the setting object will be added. To configure defaults, use [`defaults()`][method_defaults]. For synchronous operation, use [`applyDefaultsSync()`][method_apply-defaults-sync].
 
 **Arguments**
 
-  * **`keyPath`** *String* - The path to the key that we wish to observe.
-  * **`handler`** *Function* - The callback that will be invoked if the value at the chosen key path changes. Returns:
-    * `evt` *Object*
-      * `oldValue` *Any*
-      * `newValue` *Any*
+  * **`options`** *Object* (optional)
+    * `atomicSaving` *Boolean* (optional) - Whether electron-settings should create a tmp file during save to ensure data-write consistency. Defaults to `true`.
+    * `prettify` *Boolean* (optional) - Prettify the JSON output. Defaults to `false`.
+    * `overwrite` *Boolean* (optional) - Overwrite pre-existing settings with their respective default values. Defaults to `false`.
 
 **Examples**
 
 Given:
 ```json
 {
-  "foo": "bar"
+  "user": {
+    "name": {
+      "first": "George",
+      "middle": "Oscar",
+      "last": "Bluth"
+    }
+  }
 }
 ```
 
-Observe `"foo"`.
+Given:
 ```js
-settings.observe('foo' evt => {
-  console.log(evt.newValue);
-  // => 'baz'
-});
-
-settings.set('foo', 'baz');
-```
-
-Dispose the key path observer.
-```js
-const observer = settings.observe('foo' evt => {
-  console.log(evt.newValue);
-  // => 'baz'
-});
-
-settings.set('foo', 'baz').then(() => {
-  observer.dispose();
+settings.defaults({
+  "user": {
+    "age": "unknown",
+    "name": {
+      "first": "Joe",
+      "last": "Defacto"
+    }
+  }
 });
 ```
 
-
-getSettingsFilePath()
----------------------
-
-**`settings.getSettingsFilePath():string`**
-
-Returns the path to the config file. Typically found in your application's [user data directory](http://electron.atom.io/docs/api/app/#appgetpathname):
-
-  * `~/Library/Application Support/YourApp` on MacOS.
-  * `%APPDATA%/YourApp` on Windows.
-  * `$XDG_CONFIG_HOME/YourApp` or `~/.config/YourApp` on Linux.
-
-**Example**
-
+Apply defaults.
 ```js
-settings.getSettingsFilePath();
-// => /Users/You/Library/Application Support/YourApp/Settings
+settings.getSync('user.age');
+// => undefined
+
+settings.applyDefaults().then(() => {
+  settings.getSync().then(obj => {
+    // => {
+    //   user: {
+    //     age: 'unknown',
+    //     name: {
+    //       first: 'George',
+    //       middle: 'Oscar',
+    //       last: 'Bluth'
+    //     }
+    //   }
+    // }
+  });
+});
+```
+
+Apply defaults and overwrite pre-existing settings with their respective values.
+```js
+settings.getSync('user.age');
+// => undefined
+
+settings.applyDefaults({ overwrite: true }).then(() => {
+  settings.getSync().then(obj => {
+    // => {
+    //   user: {
+    //     age: 'unknown',
+    //     name: {
+    //       first: 'Joe',
+    //       middle: 'Oscar',
+    //       last: 'Defacto'
+    //     }
+    //   }
+    // }
+  });
+});
 ```
 
 
 ***
-<small>Last updated **Jul. 31st, 2016** by [Nathan Buchar].</small>
+
+
+applyDefaultsSync()
+-------------------
+
+**`settings.applyDefaultsSync([options])`**
+
+The synchronous version of [`applyDefaults()`][method_apply-defaults]
+
+
+***
+
+
+resetToDefaults()
+-----------------
+
+**`settings.resetToDefaults([options]):Promise`**
+
+Resets all settings to defaults. To configure defaults, use [`defaults()`][method_defaults]. For synchronous operation, use [`resetToDefaultsSync()`][method_reset-to-defaults-sync].
+
+**Arguments**
+
+  * **`options`** *Object* (optional)
+    * `atomicSaving` *Boolean* (optional) - Whether electron-settings should create a tmp file during save to ensure data-write consistency. Defaults to `true`.
+    * `prettify` *Boolean* (optional) - Prettify the JSON output. Defaults to `false`.
+
+**Examples**
+
+Given:
+```json
+{
+  "foo": "qux",
+  "snap": "crackle"
+}
+```
+
+Given:
+```js
+settings.defaults({
+  foo: 'bar'
+});
+```
+
+Reset to defaults.
+```js
+settings.resetToDefaults().then(() => {
+  settings.get().then(obj => {
+    // => {
+    //  foo: 'bar'
+    // }
+  });
+});
+```
+
+
+***
+
+
+resetToDefaultsSync()
+---------------------
+
+**`settings.resetToDefaultsSync([options])`**
+
+The synchronous version of [`resetToDefaults()`][method_reset-to-defaults].
+
+
+***
+<small>Last updated **Aug. 2nd, 2016** by [Nathan Buchar].</small>
 
 <small>**Having trouble?** [Get help on Gitter](https://gitter.im/nathanbuchar/electron-settings).</small>
 
@@ -635,6 +656,11 @@ settings.getSettingsFilePath();
 
 [Nathan Buchar]: (mailto:hello@nathanbuchar.com)
 
+[method_configure]: #configure
+[method_defaults]: #defaults
+[method_observe]: #observe
+[method_get-settings-file-path]: #getsettingsfilepath
+
 [method_has]: #has
 [method_has-sync]: #hassync
 [method_get]: #get
@@ -643,10 +669,9 @@ settings.getSettingsFilePath();
 [method_set-sync]: #setsync
 [method_delete]: #delete
 [method_delete-sync]: #deletesync
-[method_reset]: #reset
-[method_reset-sync]: #resetsync
 [method_clear]: #clear
 [method_clear-sync]: #clearsync
-[method_observe]: #observe
-[method_configure]: #configure
-[method_getSettingsFilePath]: #getsettingsfilepath
+[method_apply-defaults]: #applydefaults
+[method_apply-defaults-sync]: #applydefaultssync
+[method_reset-to-defaults]: #resettodefaults
+[method_reset-to-defaults-sync]: #resettodefaultssync

--- a/docs/methods.md
+++ b/docs/methods.md
@@ -10,9 +10,6 @@ Methods
 * [`configure()`][method_configure]
 * [`defaults()`][method_defaults]
 * [`observe()`][method_observe]
-* [`getSettingsFilePath()`][method_get-settings-file-path]
-
-
 * [`has()`][method_has] [*sync*][method_has-sync]
 * [`get()`][method_get] [*sync*][method_get-sync]
 * [`set()`][method_set] [*sync*][method_set-sync]
@@ -20,6 +17,7 @@ Methods
 * [`clear()`][method_clear] [*sync*][method_clear-sync]
 * [`applyDefaults()`][method_apply-defaults] [*sync*][method_apply-defaults-sync]
 * [`resetToDefaults()`][method_reset-to-defaults] [*sync*][method_reset-to-defaults-sync]
+* [`getSettingsFilePath()`][method_get-settings-file-path]
 
 
 
@@ -139,28 +137,6 @@ const observer = settings.observe('foo' evt => {
 settings.set('foo', 'qux').then(() => {
   observer.dispose();
 });
-```
-
-
-***
-
-
-getSettingsFilePath()
-------------------------
-
-**`settings.getSettingsFilePath():string`**
-
-Returns the path to the config file. Typically found in your application's [user data directory](http://electron.atom.io/docs/api/app/#appgetpathname):
-
-  * `~/Library/Application Support/YourApp` on MacOS.
-  * `%APPDATA%/YourApp` on Windows.
-  * `$XDG_CONFIG_HOME/YourApp` or `~/.config/YourApp` on Linux.
-
-**Examples**
-
-```js
-settings.getSettingsFilePath();
-// => /Users/You/Library/Application Support/YourApp/Settings
 ```
 
 
@@ -640,6 +616,28 @@ resetToDefaultsSync()
 **`settings.resetToDefaultsSync([options])`**
 
 The synchronous version of [`resetToDefaults()`][method_reset-to-defaults].
+
+
+***
+
+
+getSettingsFilePath()
+------------------------
+
+**`settings.getSettingsFilePath():string`**
+
+Returns the path to the config file. Typically found in your application's [user data directory](http://electron.atom.io/docs/api/app/#appgetpathname):
+
+  * `~/Library/Application Support/YourApp` on MacOS.
+  * `%APPDATA%/YourApp` on Windows.
+  * `$XDG_CONFIG_HOME/YourApp` or `~/.config/YourApp` on Linux.
+
+**Examples**
+
+```js
+settings.getSettingsFilePath();
+// => /Users/You/Library/Application Support/YourApp/Settings
+```
 
 
 ***

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -48,7 +48,7 @@ class Settings extends EventEmitter {
   }
 
   /**
-   * Configure global settings.
+   * Configures electron-settings global default options.
    *
    * @param {Object} options
    * @private
@@ -62,7 +62,9 @@ class Settings extends EventEmitter {
   }
 
   /**
-   * Set default settings.
+   * Sets electron-settings default settings. These will be applied upon
+   * settings file creation, as well as `applyDefaults()` and
+   * `resetToDefaults()`.
    *
    * @param {Object} obj
    * @private
@@ -87,7 +89,8 @@ class Settings extends EventEmitter {
   }
 
   /**
-   * Deletes the settings file.
+   * Deletes the settings file. This may occur if the data has become corrupted
+   * and can no longer be read.
    *
    * @private
    */
@@ -96,22 +99,23 @@ class Settings extends EventEmitter {
 
     try {
       fs.unlinkSync(pathToSettings);
+
+      debug(`settings file deleted at ${pathToSettings}`);
     } catch (e) {
-      // Either the file doesn't exist, or possibly you're totally fucked.
+      // Either the file doesn't exist, or you're totally fucked.
+      // But probably the former.. ¯\_(ツ)_/¯
     }
   }
 
   /**
-   * Doomsday scenario. Likely the JSON data has become corrupted and we must
-   * reset the file.
+   * Deletes the settings file and re-ensures its existence with default
+   * settings if possible. This is the doomsday scenario.
    *
    * @private
    */
   _resetSettingsFileSync() {
     this._unlinkSettingsFileSync();
     this._ensureSettingsFileSync();
-
-    debug('settings file has been reset');
   }
 
   /**
@@ -164,7 +168,7 @@ class Settings extends EventEmitter {
 
         fs.readJson(pathToSettings, (err, obj) => {
           if (err) {
-            debug(`malformed JSON detected at ${pathToSettings}`);
+            debug(`ERROR: malformed JSON detected at ${pathToSettings}`);
 
             this._resetSettingsFileSync();
 
@@ -194,7 +198,7 @@ class Settings extends EventEmitter {
 
       return obj;
     } catch (e) {
-      debug(`malformed JSON detected at ${pathToSettings}`);
+      debug(`ERROR: malformed JSON detected at ${pathToSettings}`);
 
       this._resetSettingsFileSync();
     }

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -1,7 +1,11 @@
 'use strict';
 
+const assert = require('assert');
 const debug = require('debug')('electron-settings');
+const deepExtend = require('deep-extend');
+const clone = require('clone');
 const electron = require('electron');
+const exists = require('file-exists');
 const fs = require('fs-extra');
 const helpers = require('key-path-helpers');
 const path = require('path');
@@ -29,104 +33,85 @@ class Settings extends EventEmitter {
     super();
 
     /**
-     * Called when the "create" event fires.
+     * Default settings.
      *
-     * @type Function
+     * @type Object
      * @private
      */
-    this._handleCreate = this._onCreate.bind(this);
+    this._defaults = {};
 
-    /**
-     * Called when the "write" event fires.
-     *
-     * @type Function
-     * @private
-     */
-    this._handleWrite = this._onWrite.bind(this);
+    // Handle "create" events.
+    this.addListener(Settings.Events.CREATE, this._onCreate.bind(this));
 
-    this._init();
+    // Handle "write" events.
+    this.addListener(Settings.Events.WRITE, this._onWrite.bind(this));
   }
 
   /**
-   * Initialize the settings instance.
+   * Configure global settings.
    *
+   * @param {Object} options
    * @private
    */
-  _init() {
-    this._initListeners();
+  _configureGlobalSettings(options) {
+    const opts = this._extendDefaultOptions(options);
+
+    Settings.DefaultOptions = opts;
+
+    debug(`global settings configured to ${JSON.stringify(opts)}`);
   }
 
   /**
-   * Register event listeners.
+   * Set default settings.
    *
+   * @param {Object} obj
    * @private
    */
-  _initListeners() {
-    this.addListener(
-      Settings.Events.CREATE,
-      this._handleCreate
-    );
-
-    this.addListener(
-      Settings.Events.WRITE,
-      this._handleWrite
-    );
+  _setDefaults(obj) {
+    this._defaults = clone(obj);
   }
 
   /**
    * Parses save options and ensures that default values are set if they are
    * not provided.
    *
-   * @param {Object} [options]
+   * @param {Object} [options={}]
    * @param {boolean} [options.atomicSaving=true]
    * @param {boolean} [options.prettify=false]
-   * @param {boolean} [options.defaults={}]
+   * @param {boolean} [options.overwrite=false]
    * @returns {Object}
    * @private
    */
-  _parseOptions(options) {
+  _extendDefaultOptions(options={}) {
     return Object.assign({}, Settings.DefaultOptions, options);
   }
 
   /**
-   * Checks if the settings file currently exists on the disk.
+   * Deletes the settings file.
    *
-   * @returns {Promise}
    * @private
    */
-  _settingsFileExists() {
-    const pathToSettings = this.getSettingsFilePath();
-
-    return new Promise((resolve, reject) => {
-      fs.stat(pathToSettings, (err, stats) => {
-        if (err) {
-          resolve(false);
-        } else {
-          resolve(stats.isFile());
-        }
-      });
-    });
-  }
-
-  /**
-   * The synchronous version of `_settingsFileExists()`.
-   *
-   * @see _settingsFileExists
-   * @returns {boolean}
-   * @private
-   */
-  _settingsFileExistsSync() {
+  _unlinkSettingsFileSync() {
     const pathToSettings = this.getSettingsFilePath();
 
     try {
-      const stats = fs.statSync(pathToSettings);
-
-      // The path does exist, but it may be a directory. Ensure that it is
-      // indeed a file.
-      return stats.isFile();
+      fs.unlinkSync(pathToSettings);
     } catch (e) {
-      return false;
+      // Either the file doesn't exist, or possibly you're totally fucked.
     }
+  }
+
+  /**
+   * Doomsday scenario. Likely the JSON data has become corrupted and we must
+   * reset the file.
+   *
+   * @private
+   */
+  _resetSettingsFileSync() {
+    this._unlinkSettingsFileSync();
+    this._ensureSettingsFileSync();
+
+    debug('settings file has been reset');
   }
 
   /**
@@ -138,14 +123,16 @@ class Settings extends EventEmitter {
    */
   _ensureSettingsFile() {
     return new Promise((resolve, reject) => {
-      this._settingsFileExists().then(exists => {
-        if (!exists) {
-          this._writeSettingsFile({}).then(resolve, reject);
+      if (!this.settingsFileExists()) {
+        const defaults = this._defaults;
+
+        this._writeSettingsFile(defaults).then(() => {
           this._emitCreateEvent();
-        } else {
           resolve();
-        }
-      });
+        }, reject);
+      } else {
+        resolve();
+      }
     });
   }
 
@@ -156,8 +143,10 @@ class Settings extends EventEmitter {
    * @private
    */
   _ensureSettingsFileSync() {
-    if (!this._settingsFileExistsSync()) {
-      this._writeSettingsFileSync({});
+    if (!this.settingsFileExists()) {
+      const defaults = this._defaults;
+
+      this._writeSettingsFileSync(defaults);
       this._emitCreateEvent();
     }
   }
@@ -173,9 +162,12 @@ class Settings extends EventEmitter {
       this._ensureSettingsFile().then(() => {
         const pathToSettings = this.getSettingsFilePath();
 
-        // TODO handle malformed JSON?
         fs.readJson(pathToSettings, (err, obj) => {
           if (err) {
+            debug(`malformed JSON detected at ${pathToSettings}`);
+
+            this._resetSettingsFileSync();
+
             reject(err);
           } else {
             resolve(obj);
@@ -197,10 +189,15 @@ class Settings extends EventEmitter {
 
     const pathToSettings = this.getSettingsFilePath();
 
-    // TODO handle malformed JSON?
-    const obj = fs.readJsonSync(pathToSettings);
+    try {
+      const obj = fs.readJsonSync(pathToSettings);
 
-    return obj;
+      return obj;
+    } catch (e) {
+      debug(`malformed JSON detected at ${pathToSettings}`);
+
+      this._resetSettingsFileSync();
+    }
   }
 
   /**
@@ -214,7 +211,7 @@ class Settings extends EventEmitter {
    * @private
    */
   _writeSettingsFile(obj, options) {
-    const opts = this._parseOptions(options);
+    const opts = this._extendDefaultOptions(options);
     const pathToSettings = this.getSettingsFilePath();
     const spaces = opts.prettify ? 2 : 0;
 
@@ -224,7 +221,6 @@ class Settings extends EventEmitter {
 
         fs.outputJson(tmpFilePath, obj, { spaces }, err => {
           if (!err) {
-            // The tmp file has saved; Overwrite the original file.
             fs.rename(tmpFilePath, pathToSettings, err => {
               if (err) {
                 reject(err);
@@ -235,6 +231,7 @@ class Settings extends EventEmitter {
             });
           } else {
             fs.unlink(tmpFilePath, () => {
+              this._resetSettingsFile();
               return reject(err);
             });
           }
@@ -259,7 +256,7 @@ class Settings extends EventEmitter {
    * @private
    */
   _writeSettingsFileSync(obj, options) {
-    const opts = this._parseOptions(options);
+    const opts = this._extendDefaultOptions(options);
     const pathToSettings = this.getSettingsFilePath();
     const spaces = opts.prettify ? 2 : 0;
 
@@ -275,7 +272,6 @@ class Settings extends EventEmitter {
           // No operation.
         }
 
-        // The file could not be saved. Exit early.
         return;
       }
 
@@ -285,18 +281,6 @@ class Settings extends EventEmitter {
     }
 
     this._emitWriteEvent();
-  }
-
-  /**
-   * Adds a key path observer for the chosen key path.
-   *
-   * @param {string} keyPath
-   * @param {Function} handler
-   * @returns {Observer}
-   * @private
-   */
-  _addKeyPathObserver(keyPath, handler) {
-    return new Observer(this, keyPath, handler);
   }
 
   /**
@@ -336,85 +320,14 @@ class Settings extends EventEmitter {
   }
 
   /**
-   * Validates that the given key path is a string.
-   *
-   * @throws if key path is not a string.
-   * @param {string} keyPath
-   */
-  _validateKeyPath(keyPath) {
-    if (typeof keyPath !== 'string') {
-      throw new TypeError(
-        `Expected key path to be a string. Got "${typeof keyPath}".`
-      );
-    }
-  }
-
-  /**
-   * Validates that the given defaults object is an object.
-   *
-   * @throws if key path is not a string or object.
-   * @param {string} [keyPath]
-   * @param {Object} options
-   */
-  _validateReset(keyPath, options) {
-    if (typeof keyPath === 'string' || typeof keyPath === 'object') {
-      options = typeof keyPath === 'object' ? arguments[0] : options;
-
-      if (typeof options.defaults !== 'undefined' && typeof options.defaults !== 'object') {
-        throw new TypeError(
-          `Expected options.defaults to be an object. Got "${typeof options.defaults}".`
-        );
-      }
-    } else {
-      throw new TypeError(
-        `Expected key path to be a string. Got "${typeof keyPath}".`
-      );
-    }
-  }
-
-  /**
-   * Validates that the given handler function is a function.
-   *
-   * @throws if handler is not a function.
-   * @param {Functiomn} handler
-   */
-  _validateHandler(handler) {
-    if (typeof handler !== 'function') {
-      throw new TypeError(
-        `Expected handler to be an function. Got "${typeof handler}".`
-      );
-    }
-  }
-
-  /**
-   * Validates that the params for `set()` and `setSync()` are valid.
-   *
-   * @throws if key path is not a string or object.
-   * @throws if key path is a string but value is not an object.
-   * @param {string} keyPath
-   * @param {any} value
-   * @param {Object} options
-   */
-  _validateSetParams(keyPath, value, options) {
-    if (typeof keyPath === 'string') {
-      if (typeof value === 'undefined') {
-        throw new TypeError('Expected value to exist.');
-      }
-    } else if (typeof keyPath !== 'object') {
-      throw new TypeError(
-        `Expected key path to be a string. Got "${typeof keyPath}".`
-      );
-    }
-  }
-
-  /**
    * Checks if the chosen key path exists within the settings object.
    *
+   * @throws if key path is not a string.
    * @param {string} keyPath
    * @returns {Promise}
    */
   has(keyPath) {
-    this._validateKeyPath(keyPath);
+    assert.strictEqual(typeof keyPath, 'string', 'Key path must be a string');
 
     return new Promise((resolve, reject) => {
       this._readSettingsFile().then(obj => {
@@ -431,7 +344,7 @@ class Settings extends EventEmitter {
    * @see has
    */
   hasSync(keyPath) {
-    this._validateKeyPath(keyPath);
+    assert.strictEqual(typeof keyPath, 'string', 'Key path must be a string');
 
     const obj = this._readSettingsFileSync();
     const keyPathExists = helpers.hasKeyPath(obj, keyPath);
@@ -442,21 +355,19 @@ class Settings extends EventEmitter {
   /**
    * Gets the value at the chosen key path.
    *
-   * @param {string} [keyPath=.]
+   * @param {string} [keyPath]
    * @returns {Promise}
    */
-  get(keyPath='.') {
-    this._validateKeyPath(keyPath);
-
+  get(keyPath) {
     return new Promise((resolve, reject) => {
       this._readSettingsFile().then(obj => {
-        if (keyPath !== '.') {
-          const value = helpers.getValueAtKeyPath(obj, keyPath);
+        let value = obj;
 
-          return resolve(value);
+        if (typeof keyPath === 'string') {
+          value = helpers.getValueAtKeyPath(obj, keyPath);
         }
 
-        resolve(obj);
+        resolve(value);
       }, reject);
     });
   }
@@ -465,48 +376,38 @@ class Settings extends EventEmitter {
    * The synchronous version of `get()`.
    *
    * @see get
-   * @returns {any}
    */
-  getSync(keyPath='.') {
-    this._validateKeyPath(keyPath);
+  getSync(keyPath) {
+    let value = this._readSettingsFileSync();
 
-    const obj = this._readSettingsFileSync();
-
-    if (keyPath !== '.') {
-      return helpers.getValueAtKeyPath(obj, keyPath);
+    if (typeof keyPath === 'string') {
+      value = helpers.getValueAtKeyPath(value, keyPath);
     }
 
-    return obj;
+    return value;
   }
 
   /**
-   * Sets the value at the chosen key path. To set the root object, simply
-   * omit the key path.
+   * Sets the value at the chosen key path.
    *
+   * @throws if key path is not a string.
+   * @throws if options is not an object.
    * @param {string} keyPath
-   * @param {any} value
+   * @param {any} [value={}]
    * @param {Object} [options={}]
-   * @param {boolean} [options.atomicSaving=true]
-   * @param {boolean} [options.prettify=false]
    * @returns {Promise}
    */
-  set(keyPath, value, options) {
-    this._validateSetParams(...arguments);
+  set(keyPath, value={}, options={}) {
+    assert.strictEqual(typeof keyPath, 'string', 'Key path must be a string');
+    assert.strictEqual(typeof options, 'object', 'Options must be an object');
 
-    if (typeof arguments[0] === 'object') {
-      value = arguments[0];
-      options = arguments[1];
+    return new Promise((resolve, reject) => {
+      this._readSettingsFile().then(obj => {
+        helpers.setValueAtKeyPath(obj, keyPath, value);
 
-      return this._writeSettingsFile(value, options);
-    } else {
-      return new Promise((resolve, reject) => {
-        this._readSettingsFile().then(obj => {
-          helpers.setValueAtKeyPath(obj, keyPath, value);
-
-          this._writeSettingsFile(obj, options).then(resolve, reject);
-        }, reject);
-      });
-    }
+        this._writeSettingsFile(obj, options).then(resolve, reject);
+      }, reject);
+    });
   }
 
   /**
@@ -514,34 +415,29 @@ class Settings extends EventEmitter {
    *
    * @see set
    */
-  setSync(keyPath, value, options) {
-    this._validateSetParams(...arguments);
+  setSync(keyPath, value={}, options={}) {
+    assert.strictEqual(typeof keyPath, 'string', 'Key path must be a string');
+    assert.strictEqual(typeof options, 'object', 'Options must be an object');
 
-    if (typeof arguments[0] === 'object') {
-      value = arguments[0];
-      options = arguments[1];
+    const obj = this._readSettingsFileSync();
 
-      this._writeSettingsFileSync(value, options);
-    } else {
-      const obj = this._readSettingsFileSync();
+    helpers.setValueAtKeyPath(obj, keyPath, value);
 
-      helpers.setValueAtKeyPath(obj, keyPath, value);
-
-      this._writeSettingsFileSync(obj, options);
-    }
+    this._writeSettingsFileSync(obj, options);
   }
 
   /**
    * Deletes the key and value at the chosen key path.
    *
+   * @throws if key path is not a string.
+   * @throws if options is not an object.
    * @param {string} keyPath
    * @param {Object} [options={}]
-   * @param {boolean} [options.atomicSaving=true]
-   * @param {boolean} [options.prettify=false]
    * @returns {Promise}
    */
   delete(keyPath, options={}) {
-    this._validateKeyPath(keyPath, options);
+    assert.strictEqual(typeof keyPath, 'string', 'Key path must be a string');
+    assert.strictEqual(typeof options, 'object', 'Options must be an object');
 
     return new Promise((resolve, reject) => {
       this._readSettingsFile().then(obj => {
@@ -558,7 +454,8 @@ class Settings extends EventEmitter {
    * @see delete
    */
   deleteSync(keyPath, options={}) {
-    this._validateKeyPath(keyPath);
+    assert.strictEqual(typeof keyPath, 'string', 'Key path must be a string');
+    assert.strictEqual(typeof options, 'object', 'Options must be an object');
 
     const obj = this._readSettingsFileSync();
 
@@ -568,79 +465,17 @@ class Settings extends EventEmitter {
   }
 
   /**
-   * Resets the chosen key path to its default value provided in
-   * options.defaults. If no key path is given, reset the entire settings
-   * object to defaults.
-   *
-   * @param {Object} [options={}]
-   * @param {boolean} [options.atomicSaving=true]
-   * @param {boolean} [options.prettify=false]
-   * @param {Object} [options.defaults={}]
-   * @returns {Promise}
-   */
-  reset(keyPath, options={}) {
-    this._validateReset(keyPath, options);
-
-    if (typeof keyPath === 'object') {
-      options = arguments[0];
-    }
-
-    const opts = this._parseOptions(options);
-    const defaults = opts.defaults;
-
-    if (typeof keyPath === 'string') {
-      return new Promise((resolve, reject) => {
-        const defaultValue = helpers.getValueAtKeyPath(defaults, keyPath);
-
-        this._readSettingsFile().then(obj => {
-          let newObj;
-
-          helpers.setValueAtKeyPath(obj, keyPath, defaultValue);
-
-          this._writeSettingsFile(obj, opts).then(resolve, reject);
-        });
-      });
-    } else {
-      return this._writeSettingsFile(defaults, opts);
-    }
-  }
-
-  /**
-   * The synchronous version of `reset()`.
-   *
-   * @see reset
-   */
-  resetSync(keyPath, options={}) {
-    this._validateReset(keyPath, options);
-
-    if (typeof keyPath === 'object') {
-      options = arguments[0];
-    }
-
-    const opts = this._parseOptions(options);
-    const defaults = opts.defaults;
-
-    if (typeof keyPath === 'string') {
-      const defaultValue = helpers.getValueAtKeyPath(defaults, keyPath);
-      const obj = this._readSettingsFileSync();
-
-      helpers.setValueAtKeyPath(obj, keyPath, defaultValue);
-
-      this._writeSettingsFileSync(obj, opts);
-    } else {
-      this._writeSettingsFileSync(defaults, opts);
-    }
-  }
-
-  /**
    * Clears all settings and replaces the file contents with an empty object.
    *
+   * @throws if options is not an object.
    * @param {Object} [options={}]
    * @param {boolean} [options.atomicSaving=true]
    * @param {boolean} [options.prettify=false]
    * @returns {Promise}
    */
-  clear(options) {
+  clear(options={}) {
+    assert.strictEqual(typeof options, 'object', 'Options must be an object');
+
     return this._writeSettingsFile({}, options);
   }
 
@@ -649,8 +484,102 @@ class Settings extends EventEmitter {
    *
    * @see clear
    */
-  clearSync(options) {
+  clearSync(options={}) {
+    assert.strictEqual(typeof options, 'object', 'Options must be an object');
+
     this._writeSettingsFileSync({}, options);
+  }
+
+  /**
+   * Sets default settings.
+   *
+   * @throws if defaults is not an object.
+   * @param {Object} [options={}
+   * @returns {Promise}
+   */
+  defaults(defaults) {
+    assert.strictEqual(typeof defaults, 'object', 'Defaults must be an object');
+
+    this._setDefaults(defaults);
+  }
+
+  /**
+   * Extends the current settings with the default settings. Optionally, you
+   * may overwrite pre-existing settings with their repsective defaults by
+   * setting `options.overwrite` to true. Set defaults using the `defaults()`
+   * method.
+   *
+   * @throws if options is not an object.
+   * @param {Object} [options={}]
+   * @returns {Promise}
+   */
+  applyDefaults(options={}) {
+    assert.strictEqual(typeof options, 'object', 'Options must be an object');
+
+    return new Promise((resolve, reject) => {
+      this._readSettingsFile().then(obj => {
+        let newObj;
+
+        if (options.overwrite === true) {
+          newObj = deepExtend({}, obj, this._defaults);
+        } else {
+          newObj = deepExtend({}, this._defaults, obj);
+        }
+
+        this._writeSettingsFile(newObj, options).then(resolve, reject);
+      });
+    });
+  }
+
+  /**
+   * The synchronous version of `applyDefaults()`.
+   *
+   * @see applyDefaults
+   */
+  applyDefaultsSync(options={}) {
+    assert.strictEqual(typeof options, 'object', 'Options must be an object');
+
+    let obj = this._readSettingsFileSync();
+    let newObj;
+
+    if (options.overwrite === true) {
+      newObj = deepExtend({}, obj, this._defaults);
+    } else {
+      newObj = deepExtend({}, this._defaults, obj);
+    }
+
+    this._writeSettingsFileSync(newObj, options);
+  }
+
+  /**
+   * Resets the settings to defaults. Set defaults using the `defaults()`
+   * method.
+   *
+   * @throws if options is not an object.
+   * @param {Object} [options={}]
+   * @returns {Promise}
+   */
+  resetToDefaults(options={}) {
+    assert.strictEqual(typeof options, 'object', 'Options must be an object');
+
+    const defaults = this._defaults;
+
+    return this._writeSettingsFile(defaults, options);
+  }
+
+  /**
+   * The synchronous version of `resetToDefaults()`.
+   *
+   * @see resetToDefaults
+   */
+  resetToDefaultsSync(options={}) {
+    assert.strictEqual(typeof options, 'object', 'Options must be an object');
+
+    const defaults = this._defaults;
+
+    this._writeSettingsFileSync(defaults, options);
+
+    this._readSettingsFileSync();
   }
 
   /**
@@ -658,40 +587,56 @@ class Settings extends EventEmitter {
    * value changes. Returns an Observer instance which has a `dispose` method.
    * To unsubscribe, simply call `dispose()` on the returned key path observer.
    *
+   * @throws if key path is not a string.
+   * @throws if handler is not a function.
    * @param {string} keyPath
    * @param {Function} handler
    * @returns {Observer}
    */
   observe(keyPath, handler) {
-    this._validateKeyPath(keyPath);
-    this._validateHandler(handler);
+    assert.strictEqual(typeof keyPath, 'string', 'Key path must be a string');
+    assert.strictEqual(typeof handler, 'function', 'Handler must be a function');
 
-    return this._addKeyPathObserver(keyPath, handler);
+    return new Observer(this, keyPath, handler);
   }
 
   /**
    * Globally configure electron-settings options.
    *
+   * @throws if options is not an object.
    * @param {Object} options
    * @param {boolean} [options.atomicSaving=true]
    * @param {boolean} [options.prettify=false]
    * @param {Object} [options.defaults={}]
    */
   configure(options) {
-    const opts = this._parseOptions(options);
+    assert.strictEqual(typeof options, 'object', 'Options must be an object');
 
-    debug(`global settings configured to ${JSON.stringify(opts)}`);
-
-    Settings.DefaultOptions = opts;
+    this._configureGlobalSettings(options);
   }
 
   /**
    * Returns the path to the settings file on the disk,
    *
-   * @returns {string}
+   * @returns {string} settingsFilePath
    */
   getSettingsFilePath() {
-    return path.join(app.getPath('userData'), Settings.FileName);
+    const userDataPath = app.getPath('userData');
+    const settingsFilePath = path.join(userDataPath, Settings.FileName);
+
+    return settingsFilePath;
+  }
+
+  /**
+   * Checks if the settings file currently exists on the disk.
+   *
+   * @returns {boolean} fileExists
+   */
+  settingsFileExists() {
+    const pathToSettings = this.getSettingsFilePath();
+    const fileExists = exists(pathToSettings);
+
+    return fileExists;
   }
 
   /**
@@ -713,7 +658,7 @@ class Settings extends EventEmitter {
 Settings.DefaultOptions = {
   atomicSaving: true,
   prettify: false,
-  defaults: {}
+  overwrite: false
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "clone": "^1.0.2",
     "debug": "^2.2.0",
     "deep-equal": "^1.0.1",
+    "deep-extend": "^0.4.1",
+    "file-exists": "^1.0.0",
     "fs-extra": "^0.26.0",
     "key-path-helpers": "^0.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-settings",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "A simple persistent user settings manager for Electron.",
   "main": "index.js",
   "scripts": {

--- a/test/spec.js
+++ b/test/spec.js
@@ -12,23 +12,29 @@ const should = chai.should();
 
 describe('electron-settings', () => {
 
-  afterEach('clear the settings', () => {
-    settings.clearSync();
+  beforeEach('configure electron-settings', () => {
+    settings.defaults({
+      foo: 'bar'
+    });
+  });
+
+  beforeEach('reset to defaults', done => {
+    settings.resetToDefaults().then(() => {
+      done();
+    });
   });
 
   describe('has()', () => {
 
     it('should return true if the key path exists', done => {
-      settings.set('foo', 'bar').then(() => {
-        settings.has('foo').then(exists => {
-          expect(exists).to.be.true;
-          done();
-        });
+      settings.has('foo').then(exists => {
+        expect(exists).to.be.true;
+        done();
       });
     });
 
     it('should return false if the key path does not exist', done => {
-      settings.has('foo').then(exists => {
+      settings.has('snap').then(exists => {
         expect(exists).to.be.false;
         done();
       });
@@ -37,28 +43,26 @@ describe('electron-settings', () => {
     it('should throw if no key path is given', () => {
       expect(() => {
         settings.has();
-      }).to.throw(TypeError, /Expected key path to be a string/);
+      }).to.throw(/Key path must be a string/);
     });
 
     it('should throw if key path is given but is not a string', () => {
       expect(() => {
         settings.has(false);
-      }).to.throw(TypeError, /Expected key path to be a string/);
+      }).to.throw(/Key path must be a string/);
     });
   });
 
   describe('hasSync()', () => {
 
     it('should return true if the key path exists', () => {
-      settings.setSync('foo', 'bar');
-
       const exists = settings.hasSync('foo');
 
       expect(exists).to.be.true;
     });
 
     it('should return false if the key path does not exist', () => {
-      const exists = settings.hasSync('foo');
+      const exists = settings.hasSync('snap');
 
       expect(exists).to.be.false;
     });
@@ -66,96 +70,76 @@ describe('electron-settings', () => {
     it('should throw if no key path is given', () => {
       expect(() => {
         settings.hasSync();
-      }).to.throw(TypeError, /Expected key path to be a string/);
+      }).to.throw(/Key path must be a string/);
     });
 
-    it('should throw if key path is given but is not a string', () => {
+    it('should throw if key path is not a string', () => {
       expect(() => {
         settings.hasSync(false);
-      }).to.throw(TypeError, /Expected key path to be a string/);
+      }).to.throw(/Key path must be a string/);
     });
   });
 
   describe('get()', () => {
 
     it('should return the value at the chosen key path', done => {
-      settings.set('foo', 'bar').then(() => {
-        settings.get('foo').then(value => {
-          expect(value).to.deep.equal('bar');
-          done();
-        });
+      settings.get('foo').then(value => {
+        expect(value).to.deep.equal('bar');
+        done();
       });
     });
 
     it('should return undefined if the key path does not exist', done => {
-      settings.get('foo').then(value => {
+      settings.get('snap').then(value => {
         expect(value).to.be.undefined;
         done();
       });
     });
 
     it('should return the entire settings object if no key path is given', done => {
-      settings.set({ foo: 'bar' }).then(() => {
-        settings.get().then(value => {
-          expect(value).to.deep.equal({ foo: 'bar' });
-          done();
-        });
+      settings.get().then(value => {
+        expect(value).to.deep.equal({ foo: 'bar' });
+        done();
       });
-    });
-
-    it('should throw if key path is given but is not a string', () => {
-      expect(() => {
-        settings.get(false);
-      }).to.throw(TypeError, /Expected key path to be a string/);
     });
   });
 
   describe('getSync()', () => {
 
     it('should return the value at the chosen key path', () => {
-      settings.setSync('foo', 'bar');
-
       const value = settings.getSync('foo');
 
       expect(value).to.deep.equal('bar');
     });
 
     it('should return undefined if the key path does not exist', () => {
-      const value = settings.getSync('foo');
+      const value = settings.getSync('snap');
 
       expect(value).to.be.undefined;
     });
 
     it('should return the entire settings object if no key path is given', () => {
-      settings.setSync({ foo: 'bar' });
-
       const value = settings.getSync();
 
       expect(value).to.deep.equal({ foo: 'bar' });
-    });
-
-    it('should throw if key path is given but is not a string', () => {
-      expect(() => {
-        settings.getSync(false);
-      }).to.throw(TypeError, /Expected key path to be a string/);
     });
   });
 
   describe('set()', () => {
 
     it('should set the value at the chosen key path', done => {
-      settings.set('foo', 'bar').then(() => {
-        settings.get('foo').then(value => {
-          expect(value).to.deep.equal('bar');
+      settings.set('snap', 'crackle').then(() => {
+        settings.get('snap').then(value => {
+          expect(value).to.deep.equal('crackle');
           done();
         });
       });
     });
 
-    it('should set the entire settings object if not key path is given', done => {
-      settings.set({ foo: 'bar' }).then(() => {
-        settings.get().then(value => {
-          expect(value).to.deep.equal({ foo: 'bar' });
+    it('should overwrite a pre-existing value', done => {
+      settings.set('foo', 'qux').then(() => {
+        settings.get('foo').then(value => {
+          expect(value).to.deep.equal('qux');
           done();
         });
       });
@@ -164,68 +148,66 @@ describe('electron-settings', () => {
     it('should throw if no key path is given', () => {
       expect(() => {
         settings.set();
-      }).to.throw(TypeError, /Expected key path to be a string/);
+      }).to.throw(/Key path must be a string/);
     });
 
-    it('should throw if key path is given but is not a string or object', () => {
+    it('should throw if key path is not a string', () => {
       expect(() => {
         settings.set(false);
-      }).to.throw(TypeError, /Expected key path to be a string/);
+      }).to.throw(/Key path must be a string/);
     });
 
-    it('should throw if key path is a string but no value is given', () => {
+    it('should throw if options is not an object', () => {
       expect(() => {
-        settings.set('foo');
-      }).to.throw(TypeError, /Expected value to exist/);
+        settings.set('foo', 'bar', false);
+      }).to.throw(/Options must be an object/);
     });
   });
 
   describe('setSync()', () => {
 
     it('should set the value at the chosen key path', () => {
-      settings.setSync('foo', 'bar');
+      settings.setSync('snap', 'crackle');
+
+      const value = settings.getSync('snap');
+
+      expect(value).to.deep.equal('crackle');
+    });
+
+    it('should overwrite a pre-existing value', () => {
+      settings.setSync('foo', 'qux');
 
       const value = settings.getSync('foo');
 
-      expect(value).to.deep.equal('bar');
-    });
-
-    it('should set the entire settings object if not key path is given', () => {
-      settings.setSync({ foo: 'bar' });
-
-      const value = settings.getSync();
-
-      expect(value).to.deep.equal({ foo: 'bar' });
+      expect(value).to.deep.equal('qux');
     });
 
     it('should throw if no key path is given', () => {
       expect(() => {
         settings.setSync();
-      }).to.throw(TypeError, /Expected key path to be a string/);
+      }).to.throw(/Key path must be a string/);
     });
 
-    it('should throw if key path is given but is not a string or object', () => {
+    it('should throw if key path is not a string', () => {
       expect(() => {
         settings.setSync(false);
-      }).to.throw(TypeError, /Expected key path to be a string/);
+      }).to.throw(/Key path must be a string/);
     });
 
-    it('should throw if key path is a string but no value is given', () => {
+    it('should throw if options is not an object', () => {
       expect(() => {
-        settings.setSync('foo');
-      }).to.throw(TypeError, /Expected value to exist/);
+        settings.setSync('foo', 'bar', false);
+      }).to.throw(/Options must be an object/);
     });
   });
 
   describe('delete()', () => {
 
     it('should delete the value at the chosen key path', done => {
-      settings.set('foo', 'bar').then(() => {
-        settings.delete('foo').then(value => {
-          settings.get('foo').then(value => {
-            expect(value).to.be.undefined;
-            done();
-          });
+      settings.delete('foo').then(() => {
+        settings.get('foo').then(value => {
+          expect(value).to.be.undefined;
+          done();
         });
       });
     });
@@ -233,20 +215,25 @@ describe('electron-settings', () => {
     it('should throw if no key path is given', () => {
       expect(() => {
         settings.delete();
-      }).to.throw(TypeError, /Expected key path to be a string/);
+      }).to.throw(/Key path must be a string/);
     });
 
-    it('should throw if key path is given but is not a string', () => {
+    it('should throw if key path is not a string', () => {
       expect(() => {
         settings.delete(false);
-      }).to.throw(TypeError, /Expected key path to be a string/);
+      }).to.throw(/Key path must be a string/);
+    });
+
+    it('should throw if options is not an object', () => {
+      expect(() => {
+        settings.delete('foo', false);
+      }).to.throw(/Options must be an object/);
     });
   });
 
   describe('deleteSync()', () => {
 
     it('should delete the value at the chosen key path', () => {
-      settings.setSync('foo', 'bar');
       settings.deleteSync('foo');
 
       const value = settings.getSync('foo');
@@ -257,162 +244,235 @@ describe('electron-settings', () => {
     it('should throw if no key path is given', () => {
       expect(() => {
         settings.deleteSync();
-      }).to.throw(TypeError, /Expected key path to be a string/);
+      }).to.throw(/Key path must be a string/);
     });
 
-    it('should throw if key path is given but is not a string', () => {
+    it('should throw if key path not a string', () => {
       expect(() => {
         settings.deleteSync(false);
-      }).to.throw(TypeError, /Expected key path to be a string/);
-    });
-  });
-
-  describe('reset()', () => {
-
-    it('should reset the value at the given key path to its default value', done => {
-      settings.set('foo', 'baz').then(() => {
-        settings.reset('foo', { defaults: { foo: 'bar', snap: 'crackle' } }).then(() => {
-          settings.get('foo').then(value => {
-            expect(value).to.deep.equal('bar');
-            done();
-          });
-        });
-      });
+      }).to.throw(/Key path must be a string/);
     });
 
-    it('should reset the entire settings object to defaults', done => {
-      settings.set('foo', 'baz').then(() => {
-        settings.reset({ defaults: { foo: 'bar', snap: 'crackle' } }).then(() => {
-          settings.get().then(value => {
-            expect(value).to.deep.equal({ foo: 'bar', snap: 'crackle' });
-            done();
-          });
-        });
-      });
-    });
-
-    it('should throw if no key path is given', () => {
+    it('should throw if options is not an object', () => {
       expect(() => {
-        settings.reset();
-      }).to.throw(TypeError, /Expected key path to be a string/);
-    });
-
-    it('should throw if options.defaults is not an object', () => {
-      expect(() => {
-        settings.reset('foo', { defaults: false });
-      }).to.throw(TypeError, /Expected options\.defaults to be an object/);
-    });
-  });
-
-  describe('resetSync()', () => {
-
-    it('should reset the value at the given key path to its default value', () => {
-      settings.setSync('foo', 'baz');
-      settings.resetSync('foo', { defaults: { foo: 'bar', snap: 'crackle' } });
-
-      const value = settings.getSync('foo');
-
-      expect(value).to.deep.equal('bar');
-    });
-
-    it('should reset the entire settings object to defaults', () => {
-      settings.setSync('foo', 'baz');
-      settings.resetSync({ defaults: { foo: 'bar', snap: 'crackle' } });
-
-      const value = settings.getSync();
-
-      expect(value).to.deep.equal({ foo: 'bar', snap: 'crackle' });
-    });
-
-    it('should throw if no key path is given', () => {
-      expect(() => {
-        settings.resetSync();
-      }).to.throw(TypeError, /Expected key path to be a string/);
-    });
-
-    it('should throw if options.defaults is not an object', () => {
-      expect(() => {
-        settings.resetSync('foo', { defaults: false });
-      }).to.throw(TypeError, /Expected options\.defaults to be an object/);
+        settings.deleteSync('foo', false);
+      }).to.throw(/Options must be an object/);
     });
   });
 
   describe('clear()', () => {
 
     it('should clear the entire settings object', done => {
-      settings.set('foo', 'bar').then(() => {
-        settings.clear().then(() => {
-          settings.get().then(value => {
-            expect(value).to.be.empty;
-            done();
-          });
+      settings.clear().then(() => {
+        settings.get().then(value => {
+          expect(value).to.be.empty;
+          done();
         });
       });
+    });
+
+    it('should throw if options is not an object', () => {
+      expect(() => {
+        settings.clear(false);
+      }).to.throw(/Options must be an object/);
     });
   });
 
   describe('clearSync()', () => {
 
     it('should clear the entire settings object', () => {
-      settings.setSync('foo', 'bar');
       settings.clearSync();
 
       const value = settings.getSync();
 
       expect(value).to.be.empty;
     });
+
+    it('should throw if options is not an object', () => {
+      expect(() => {
+        settings.clearSync(false);
+      }).to.throw(/Options must be an object/);
+    });
   });
 
-  describe('observer()', () => {
+  describe('defaults()', () => {
 
-    it('should observe the given key path', done => {
-      settings.set('foo', 'bar').then(() => {
-        const observer = settings.observe('foo', evt => {
-          expect(evt.oldValue).to.deep.equal('bar');
-          expect(evt.newValue).to.deep.equal('baz');
-          observer.dispose();
+    it('should set global defaults', done => {
+      settings.defaults({
+        snap: 'crackle'
+      });
+
+      settings.resetToDefaults().then(() => {
+        settings.get().then(obj => {
+          expect(obj).to.deep.equal({ snap: 'crackle' });
           done();
         });
-
-        settings.setSync('foo', 'baz');
       });
     });
 
-    it('should dispose the key path observer', done => {
-      settings.set('foo', 'bar').then(() => {
-        const observer = settings.observe('foo', evt => {
-          expect(evt).to.not.exist;
+    it('should throw if defaults is not an object', () => {
+      expect(() => {
+        settings.defaults(false);
+      }).to.throw(/Defaults must be an object/);
+    });
+  });
+
+  describe('applyDefaults()', () => {
+
+    it('should apply defaults', done => {
+      settings.defaults({
+        foo: 'qux',
+        snap: 'crackle'
+      });
+
+      settings.applyDefaults().then(() => {
+        settings.get().then(obj => {
+          expect(obj).to.deep.equal({ foo: 'bar', snap: 'crackle' });
+          done();
         });
+      });
+    });
 
+    it('should apply defaults and overwrite pre-existing values', done => {
+      settings.defaults({
+        foo: 'qux',
+        snap: 'crackle'
+      });
+
+      settings.applyDefaults({ overwrite: true }).then(() => {
+        settings.get().then(obj => {
+          expect(obj).to.deep.equal({ foo: 'qux', snap: 'crackle' });
+          done();
+        });
+      });
+    });
+
+    it('should throw if options is not an object', () => {
+      expect(() => {
+        settings.applyDefaults(false);
+      }).to.throw(/Options must be an object/);
+    });
+  });
+
+  describe('applyDefaultsSync()', () => {
+
+    it('should apply defaults', () => {
+      settings.defaults({
+        foo: 'qux',
+        snap: 'crackle'
+      });
+
+      settings.applyDefaultsSync();
+
+      const val = settings.getSync();
+
+      expect(val).to.deep.equal({ foo: 'bar', snap: 'crackle' });
+    });
+
+    it('should apply defaults and overwrite pre-existing values', () => {
+      settings.defaults({
+        foo: 'qux',
+        snap: 'crackle'
+      });
+
+      settings.applyDefaultsSync({ overwrite: true });
+
+      const val = settings.getSync();
+
+      expect(val).to.deep.equal({ foo: 'qux', snap: 'crackle' });
+    });
+
+    it('should throw if options is not an object', () => {
+      expect(() => {
+        settings.applyDefaults(false);
+      }).to.throw(/Options must be an object/);
+    });
+  });
+
+  describe('resetToDefaults()', () => {
+
+    it('should reset to defaults', done => {
+      settings.set('foo', 'qux').then(() => {
+        settings.resetToDefaults().then(() => {
+          settings.get().then(obj => {
+            expect(obj).to.deep.equal({ foo: 'bar' });
+            done();
+          });
+        });
+      });
+    });
+
+    it('should throw if options is not an object', () => {
+      expect(() => {
+        settings.resetToDefaults(false);
+      }).to.throw(/Options must be an object/);
+    });
+  });
+
+  describe('resetToDefaultsSync()', () => {
+
+    it('should reset to defaults', () => {
+      settings.setSync('foo', 'qux');
+      settings.resetToDefaultsSync();
+
+      const val = settings.getSync();
+
+      expect(val).to.deep.equal({ foo: 'bar' });
+    });
+
+    it('should throw if options is not an object', () => {
+      expect(() => {
+        settings.resetToDefaultsSync(false);
+      }).to.throw(/Options must be an object/);
+    });
+  });
+
+  describe('observe()', () => {
+
+    it('should observe the given key path', done => {
+      const observer = settings.observe('foo', evt => {
+        expect(evt.oldValue).to.deep.equal('bar');
+        expect(evt.newValue).to.deep.equal('qux');
         observer.dispose();
-        settings.setSync('foo', 'baz');
-
         done();
       });
+
+      settings.setSync('foo', 'qux');
+    });
+
+    it('should dispose the key path observer', done => {
+      const observer = settings.observe('foo', evt => {
+        expect(evt).to.not.exist;
+      });
+
+      observer.dispose();
+      settings.setSync('foo', 'baz');
+
+      done();
     });
 
     it('should throw if no key path is given', () => {
       expect(() => {
         settings.observe();
-      }).to.throw(TypeError, /Expected key path to be a string/);
+      }).to.throw(/Key path must be a string/);
     });
 
     it('should throw if key path is given but is not a string', () => {
       expect(() => {
         settings.observe(false);
-      }).to.throw(TypeError, /Expected key path to be a string/);
+      }).to.throw(/Key path must be a string/);
     });
 
     it('should throw if no handler is given', () => {
       expect(() => {
         settings.observe('foo');
-      }).to.throw(TypeError, /Expected handler to be an function/);
+      }).to.throw(/Handler must be a function/);
     });
 
     it('should throw if handler is given but is not a function', () => {
       expect(() => {
         settings.observe('foo', false);
-      }).to.throw(TypeError, /Expected handler to be an function/);
+      }).to.throw(/Handler must be a function/);
     });
   });
 
@@ -431,4 +491,5 @@ describe('electron-settings', () => {
       expect(settings.getSettingsFilePath()).to.be.a.string;
     });
   });
+
 });


### PR DESCRIPTION
* Adds `defaults()`.
* Adds `applyDefaults()` and `applyDefaultsSync()`.
* Adds `resetToDefaults()` and `resetToDefaultsSync()`.
* Adds `util.assert` for parameter checks.
* Adds support for resetting the settings file if malformed JSON data is encountered.
* Removes `reset()` and `resetSync()` (breaking).
* Removes the option to omit the key path in `set()` and `setSync()`. A key path is now required (breaking).
* Removes the option to specify default settings via `configure()`.
* Fixes initial settings creation. Before it wouldn't apply default settings.
* Fixes Changelog.
* Updates Readme.