### PR TITLE
Added basic encryption

### DIFF
--- a/lib/encryptor.js
+++ b/lib/encryptor.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const encryptjs = require('encryptjs');
+const fs = require('fs-extra');
+
+export function outputEncryptedJson(filePath, obj, key, callback) {
+	fs.writeFile(filePath, encryptjs.encrypt(JSON.stringify(obj), key, 256), callback);
+}
+
+export function readEncryptedJson(filePath, key, callback) {
+	fs.readFile(filePath, (err, ciphertext) => {
+			if(err) callback(err, null);
+			else callback(err, JSON.parse(encryptjs.decrypt(ciphertext, key, 256)));
+	});
+}
+
+export function outputEncryptedJsonSync(filePath, obj, key) {
+	fs.writeFileSync(filePath, encryptjs.encrypt(JSON.stringify(obj), key, 256));
+}
+
+export function readEncryptedJsonSync(filePath, key) {
+	return JSON.parse(encryptjs.decrypt(fs.readFileSync(filePath), key, 256));
+}

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -11,6 +11,7 @@ const helpers = require('key-path-helpers');
 const path = require('path');
 const { EventEmitter } = require('events');
 
+const Encryptor = require('./encryptor');
 const Observer = require('./observer');
 
 /**
@@ -162,11 +163,12 @@ class Settings extends EventEmitter {
    * @private
    */
   _readSettingsFile() {
+		const opts = Settings.DefaultOptions;
     return new Promise((resolve, reject) => {
       this._ensureSettingsFile().then(() => {
         const pathToSettings = this.getSettingsFilePath();
 
-        fs.readJson(pathToSettings, (err, obj) => {
+				const readCompleted = (err, obj) => {
           if (err) {
             debug(`ERROR: malformed JSON detected at ${pathToSettings}`);
 
@@ -176,7 +178,11 @@ class Settings extends EventEmitter {
           } else {
             resolve(obj);
           }
-        });
+        }
+
+				if (opts.key) Encryptor.readEncryptedJson(pathToSettings, opts.key, readCompleted);
+        else fs.readJson(pathToSettings, readCompleted);
+
       }, reject);
     });
   }
@@ -189,12 +195,15 @@ class Settings extends EventEmitter {
    * @private
    */
   _readSettingsFileSync() {
+		const opts = Settings.DefaultOptions;
     this._ensureSettingsFileSync();
 
     const pathToSettings = this.getSettingsFilePath();
 
     try {
-      const obj = fs.readJsonSync(pathToSettings);
+			const obj = (opts.key)
+				? Encryptor.readEncryptedJsonSync(pathToSettings, opts.key)
+				: fs.readJsonSync(pathToSettings);
 
       return obj;
     } catch (e) {
@@ -223,7 +232,7 @@ class Settings extends EventEmitter {
       if (opts.atomicSaving) {
         const tmpFilePath = `${pathToSettings}-tmp`;
 
-        fs.outputJson(tmpFilePath, obj, { spaces }, err => {
+				const outputCompleted = err => {
           if (!err) {
             fs.rename(tmpFilePath, pathToSettings, err => {
               if (err) {
@@ -239,16 +248,25 @@ class Settings extends EventEmitter {
               return reject(err);
             });
           }
-        });
+        }
+
+				if (opts.key) Encryptor.outputEncryptedJson(tmpFilePath, obj, opts.key, outputCompleted);
+				else fs.outputJson(tmpFilePath, obj, { spaces }, outputCompleted);
+
       } else {
-        fs.outputJson(pathToSettings, obj, { spaces }, err => {
+
+				const outputCompleted = err => {
           if (err) {
             reject(err);
           } else {
             this._emitWriteEvent();
             resolve();
           }
-        });
+        }
+
+				if (opts.key) Encryptor.outputEncryptedJson(pathToSettings, obj, opts.key, outputCompleted);
+        else fs.outputJson(pathToSettings, obj, { spaces }, outputCompleted);
+
       }
     });
   }
@@ -268,7 +286,8 @@ class Settings extends EventEmitter {
       const tmpFilePath = `${pathToSettings}-tmp`;
 
       try {
-        fs.outputJsonSync(tmpFilePath, obj, { spaces });
+        if (opts.key) Encryptor.outputEncryptedJsonSync(tmpFilePath, obj, opts.key);
+				else fs.outputJsonSync(tmpFilePath, obj, { spaces });
       } catch (e) {
         try {
           fs.unlinkSync(tmpFilePath);
@@ -281,7 +300,8 @@ class Settings extends EventEmitter {
 
       fs.renameSync(tmpFilePath, pathToSettings);
     } else {
-      fs.outputJsonSync(pathToSettings, obj, { spaces });
+			if (opts.key) Encryptor.outputEncryptedJsonSync(pathToSettings, obj, opts.key);
+      else fs.outputJsonSync(pathToSettings, obj, { spaces });
     }
 
     this._emitWriteEvent();

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "debug": "^2.2.0",
     "deep-equal": "^1.0.1",
     "deep-extend": "^0.4.1",
+		"encryptjs": "^1.1.6",
     "file-exists": "^2.0.0",
     "fs-extra": "^0.30.0",
     "key-path-helpers": "^0.4.0"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "debug": "^2.2.0",
     "deep-equal": "^1.0.1",
     "deep-extend": "^0.4.1",
-		"encryptjs": "^1.1.6",
+		"encryptjs": "^2.0.0",
     "file-exists": "^2.0.0",
     "fs-extra": "^0.30.0",
     "key-path-helpers": "^0.4.0"


### PR DESCRIPTION
Added the ability to encrypt the JSON file, by passing a key option.

I can elaborate further on why I believe this to be a desirable feature, if required. Alternatively I could add a save/load hook instead, to allow the ability to encrypt/decrypt the JSON outside of the library if it is deemed not within the projects goals.

I just realised that I was working on an outdated codebase. Ill resolve any conflicts if theres an appetite for this feature. Im also looking feedback on any other elements of the PR, style etc.
