### PR TITLE
fast write cause JSON malformed

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -9,6 +9,7 @@ const exists = require('file-exists');
 const fs = require('fs-extra');
 const helpers = require('key-path-helpers');
 const path = require('path');
+const temp = require('temp').track();
 const { EventEmitter } = require('events');
 
 const Observer = require('./observer');
@@ -327,7 +328,7 @@ class Settings extends EventEmitter {
 
     return new Promise((resolve, reject) => {
       if (opts.atomicSaving) {
-        const tmpFilePath = `${pathToSettings}-tmp`;
+        const tmpFilePath = temp.path({suffix: '.json'});
 
         fs.outputJson(tmpFilePath, obj, { spaces }, err => {
           if (!err) {
@@ -375,7 +376,7 @@ class Settings extends EventEmitter {
     const spaces = opts.prettify ? 2 : 0;
 
     if (opts.atomicSaving) {
-      const tmpFilePath = `${pathToSettings}-tmp`;
+        const tmpFilePath = temp.path({suffix: '.json'});
 
       try {
         fs.outputJsonSync(tmpFilePath, obj, { spaces });

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -328,7 +328,7 @@ class Settings extends EventEmitter {
 
     return new Promise((resolve, reject) => {
       if (opts.atomicSaving) {
-        const tmpFilePath = temp.path({suffix: '.json'});
+        const tmpFilePath = temp.path({dir:path.dirname(pathToSettings), suffix: '.json'});
 
         fs.outputJson(tmpFilePath, obj, { spaces }, err => {
           if (!err) {
@@ -376,7 +376,7 @@ class Settings extends EventEmitter {
     const spaces = opts.prettify ? 2 : 0;
 
     if (opts.atomicSaving) {
-        const tmpFilePath = temp.path({suffix: '.json'});
+        const tmpFilePath = temp.path({dir:path.dirname(pathToSettings), suffix: '.json'});
 
       try {
         fs.outputJsonSync(tmpFilePath, obj, { spaces });

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -329,7 +329,7 @@ class Settings extends EventEmitter {
     return new Promise((resolve, reject) => {
       if (opts.atomicSaving) {
         const tmpFileDir = path.dirname(pathToSettings);
-        const tmpFilePath = temp.path({ dir:tmpFileDir, suffix: '.json' });
+        const tmpFilePath = temp.path({ dir: tmpFileDir, suffix: '.json' });
 
         fs.outputJson(tmpFilePath, obj, { spaces }, err => {
           if (!err) {
@@ -378,7 +378,7 @@ class Settings extends EventEmitter {
 
     if (opts.atomicSaving) {
         const tmpFileDir = path.dirname(pathToSettings);
-        const tmpFilePath = temp.path({ dir:tmpFileDir, suffix: '.json' });
+        const tmpFilePath = temp.path({ dir: tmpFileDir, suffix: '.json' });
 
       try {
         fs.outputJsonSync(tmpFilePath, obj, { spaces });

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -328,7 +328,8 @@ class Settings extends EventEmitter {
 
     return new Promise((resolve, reject) => {
       if (opts.atomicSaving) {
-        const tmpFilePath = temp.path({dir:path.dirname(pathToSettings), suffix: '.json'});
+        const tmpFileDir = path.dirname(pathToSettings);
+        const tmpFilePath = temp.path({ dir:tmpFileDir, suffix: '.json' });
 
         fs.outputJson(tmpFilePath, obj, { spaces }, err => {
           if (!err) {
@@ -376,7 +377,8 @@ class Settings extends EventEmitter {
     const spaces = opts.prettify ? 2 : 0;
 
     if (opts.atomicSaving) {
-        const tmpFilePath = temp.path({dir:path.dirname(pathToSettings), suffix: '.json'});
+        const tmpFileDir = path.dirname(pathToSettings);
+        const tmpFilePath = temp.path({ dir:tmpFileDir, suffix: '.json' });
 
       try {
         fs.outputJsonSync(tmpFilePath, obj, { spaces });

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "deep-extend": "^0.4.1",
     "file-exists": "^2.0.0",
     "fs-extra": "^0.30.0",
-    "key-path-helpers": "^0.4.0"
+    "key-path-helpers": "^0.4.0",
+    "temp": "^0.8.3"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
When quickly calling multiple set you end up with a malformed JSON. This is because you have concurrent write calls on the temp file.

I simply solved this by creating unique temp file on each write.