### PR TITLE
Observe changes when atomic saving is done on a different thread

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -439,6 +439,13 @@ class Settings extends EventEmitter {
       debug(`detected change to settings file`);
 
       this._emitWriteEvents();
+    } else {
+      debug(`detected rename to settings file`);
+
+      // Need to re-observe the settings file per NodeJS docs
+      // See: https://nodejs.org/docs/latest/api/fs.html#fs_inodes
+      this._observeSettingsFile(true);
+      this._emitWriteEvents();
     }
   }
 

--- a/test/spec.js
+++ b/test/spec.js
@@ -582,6 +582,20 @@ describe('electron-settings', () => {
           settings.observe('foo', false);
         }).to.throw(/Handler must be a function/);
       });
+
+      it('should observe changes if updated on another (atomic) thread', done => {
+        const pathToSettings = settings.getSettingsFilePath();
+        const tmpFilePath = `${pathToSettings}-tmp`;
+
+        const observer = settings.observe('foo', ({newValue, oldValue}) => {
+          expect(newValue).to.deep.equal('barUpdated');
+          observer.dispose();
+          done();
+        });
+
+        fs.outputFileSync(tmpFilePath, '{ "foo": "barUpdated" }');
+        fs.renameSync(tmpFilePath, pathToSettings);
+      });
     });
 
     describe('configure()', () => {


### PR DESCRIPTION
I had a problem where I was using electron-settings on two different threads in the same Electron app.  I was trying to use observe to detect when the other thread would do the updating, but would not work (when atomicSave is true) due to it using 'rename'.

Also, due to the inode nature (see https://nodejs.org/docs/latest/api/fs.html#fs_inodes) I had to call _obsereSettingsFile(true) again.