### PR TITLE
Support an array of string or escaped dots as a key path.

### DIFF
--- a/lib/settings-helpers.js
+++ b/lib/settings-helpers.js
@@ -8,6 +8,35 @@
  */
 
 /**
+ * Tests if the provided path represents the root path.
+ * @param keyPath {string|string[]} path to a key
+ * @return {boolean} true for the root path, false otherwise
+ */
+module.exports.isRootPath = keyPath => {
+  /* Nicely work for both string and array
+   * A proper version would test if array or string */
+  return keyPath.length == 0;
+}
+
+/**
+ * Converts the given key path into the various keys to call on an object
+ * @param {string|string[]} keyPath
+ * @return {string[]} keys along the path
+ */
+const resolvePath = keyPath => {
+  if (Array.isArray(keyPath)) {
+    // Make a defensive copy to pop and push into the path
+    return keyPath.slice();
+  } else {
+    // We split the string according to '.', but not for escaped dots '\\.'
+    return keyPath.match(/(\\.|[^.])+/g)
+      .map(part => part.replace(/\\\./g, '.'));
+  }
+};
+// Exported for tests
+module.exports._resolvePath = resolvePath;
+
+/**
  * Checks if the given object contains the given key path.
  *
  * @param {Object} obj
@@ -15,7 +44,7 @@
  * @returns {boolean}
  */
 module.exports.hasKeyPath = (obj, keyPath) => {
-  const keys = keyPath.split(/\./);
+  const keys = resolvePath(keyPath);
 
   for (let i = 0, len = keys.length; i < len; i++) {
     const key = keys[i];
@@ -38,7 +67,7 @@ module.exports.hasKeyPath = (obj, keyPath) => {
  * @returns {any}
  */
 module.exports.getValueAtKeyPath = (obj, keyPath) => {
-  const keys = keyPath.split(/\./);
+  const keys = resolvePath(keyPath);
 
   for (let i = 0, len = keys.length; i < len; i++) {
     const key = keys[i];
@@ -61,7 +90,7 @@ module.exports.getValueAtKeyPath = (obj, keyPath) => {
  * @param {any} value
  */
 module.exports.setValueAtKeyPath = (obj, keyPath, value) => {
-  const keys = keyPath.split(/\./);
+  const keys = resolvePath(keyPath);
 
   while (keys.length > 1) {
     const key = keys.shift();
@@ -83,7 +112,7 @@ module.exports.setValueAtKeyPath = (obj, keyPath, value) => {
  * @param {string} keyPath
  */
 module.exports.deleteValueAtKeyPath = (obj, keyPath) => {
-  const keys = keyPath.split(/\./);
+  const keys = resolvePath(keyPath);
 
   while (keys.length > 1) {
     const key = keys.shift();

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -94,6 +94,21 @@ class Settings extends EventEmitter {
   }
 
   /**
+   * Checks the type of the path argument provided to a method.
+   * @param {*} value
+   * @param {string?} hint complement to the default message about the path type
+   * @throws if the type is not a string or an array of strings
+   */
+  _chechKeyPathType(value, hint) {
+    const baseMessage = 'Key path parameter must be a string or an array of strings.';
+    const message = hint ? `${baseMessage} ${hint}` : baseMessage;
+    const hasCorrectType =
+      (typeof value) === 'string'
+      || Array.isArray(value) && value.every(part => (typeof part) === 'string')
+    assert.strictEqual(hasCorrectType, true, message);
+  }
+
+  /**
    * Returns the settings file path.
    *
    * @returns {string}
@@ -275,7 +290,7 @@ class Settings extends EventEmitter {
    * Sets the value at the given key path, or the entire settings object if
    * an empty key path is given.
    *
-   * @param {string} keyPath
+   * @param {string|string[]} keyPath
    * @param {any} value
    * @param {Object} opts
    * @private
@@ -283,7 +298,7 @@ class Settings extends EventEmitter {
   _setValueAtKeyPath(keyPath, value, opts) {
     let obj = value;
 
-    if (keyPath !== '') {
+    if (!Helpers.isRootPath(keyPath)) {
       obj = this._readSettings();
 
       Helpers.setValueAtKeyPath(obj, keyPath, value);
@@ -297,7 +312,7 @@ class Settings extends EventEmitter {
    * path to the default value, if provided, if the key does not exist. If an
    * empty key path is given, the entire settings object will be returned.
    *
-   * @param {string} keyPath
+   * @param {string|string[]} keyPath
    * @param {any} [defaultValue]
    * @returns {any}
    * @private
@@ -305,7 +320,7 @@ class Settings extends EventEmitter {
   _getValueAtKeyPath(keyPath, defaultValue) {
     const obj = this._readSettings();
 
-    if (keyPath !== '') {
+    if (!Helpers.isRootPath(keyPath)) {
       const exists = Helpers.hasKeyPath(obj, keyPath);
       const value = Helpers.getValueAtKeyPath(obj, keyPath);
 
@@ -328,12 +343,12 @@ class Settings extends EventEmitter {
    * Deletes the key and value at the given key path, or clears the entire
    * settings object if an empty key path is given.
    *
-   * @param {string} keyPath
+   * @param {string|string[]} keyPath
    * @param {Object} opts
    * @private
    */
   _deleteValueAtKeyPath(keyPath, opts) {
-    if (keyPath === '') {
+    if (Helpers.isRootPath(keyPath)) {
       this._writeSettings({}, opts);
     } else {
       const obj = this._readSettings();
@@ -351,7 +366,7 @@ class Settings extends EventEmitter {
    * if the value changes. To unsubscribe from changes, call `dispose()`
    * on the Observer instance that is returned.
    *
-   * @param {string} keyPath
+   * @param {string|string[]} keyPath
    * @param {Function} handler
    * @returns {Observer}
    * @private
@@ -366,12 +381,12 @@ class Settings extends EventEmitter {
    * Returns a boolean indicating whether the settings object contains
    * the given key path.
    *
-   * @param {string} keyPath
+   * @param {string|string[]} keyPath
    * @returns {boolean}
    * @public
    */
   has(keyPath) {
-    assert.strictEqual(typeof keyPath, 'string', 'First parameter must be a string');
+    this._chechKeyPathType(keyPath);
 
     return this._checkKeyPathExists(keyPath);
   }
@@ -379,7 +394,7 @@ class Settings extends EventEmitter {
   /**
    * Sets the value at the given key path.
    *
-   * @param {string} keyPath
+   * @param {string|string[]} keyPath
    * @param {any} value
    * @param {Object} [opts={}]
    * @param {boolean} [opts.prettify=false]
@@ -387,7 +402,7 @@ class Settings extends EventEmitter {
    * @public
    */
   set(keyPath, value, opts = {}) {
-    assert.strictEqual(typeof keyPath, 'string', 'First parameter must be a string. Did you mean to use `setAll()` instead?');
+    this._chechKeyPathType(keyPath, 'Did you mean to use `setAll()` instead?');
     assert.strictEqual(typeof opts, 'object', 'Second parameter must be an object');
 
     this._setValueAtKeyPath(keyPath, value, opts);
@@ -417,13 +432,13 @@ class Settings extends EventEmitter {
    * Returns the value at the given key path, or sets the value at that key
    * path to the default value, if provided, if the key does not exist.
    *
-   * @param {string} keyPath
+   * @param {string|string[]} keyPath
    * @param {any} [defaultValue]
    * @returns {any}
    * @public
    */
   get(keyPath, defaultValue) {
-    assert.strictEqual(typeof keyPath, 'string', 'First parameter must be a string. Did you mean to use `getAll()` instead?');
+    this._chechKeyPathType(keyPath, 'Did you mean to use `getAll()` instead?');
 
     return this._getValueAtKeyPath(keyPath, defaultValue);
   }
@@ -441,14 +456,14 @@ class Settings extends EventEmitter {
   /**
    * Deletes the key and value at the given key path.
    *
-   * @param {string} keyPath
+   * @param {string|string[]} keyPath
    * @param {Object} [opts={}]
    * @param {boolean} [opts.prettify=false]
    * @returns {Settings}
    * @public
    */
   delete(keyPath, opts = {}) {
-    assert.strictEqual(typeof keyPath, 'string', 'First parameter must be a string. Did you mean to use `deleteAll()` instead?');
+    this._chechKeyPathType(keyPath, 'Did you mean to use `deleteAll()` instead?');
     assert.strictEqual(typeof opts, 'object', 'Second parameter must be an object');
 
     this._deleteValueAtKeyPath(keyPath, opts);
@@ -477,13 +492,13 @@ class Settings extends EventEmitter {
    * if the value changes. To unsubscribe from changes, call `dispose()`
    * on the Observer instance that is returned.
    *
-   * @param {string} keyPath
+   * @param {string|string[]} keyPath
    * @param {Function} handler
    * @returns {Observer}
    * @public
    */
   watch(keyPath, handler) {
-    assert.strictEqual(typeof keyPath, 'string', 'First parameter must be a string');
+    this._chechKeyPathType(keyPath);
     assert.strictEqual(typeof handler, 'function', 'Second parameter must be a function');
 
     return this._watchValueAtKeyPath(keyPath, handler);


### PR DESCRIPTION
This stems from issue [#91](https://github.com/nathanbuchar/electron-settings/issues/91).

The idea is to make possible to have `.` (dot) in a key, thus not
interpreting all `.` as key separators.
One can escape non-separating `.` as `\\.`, or provide an explicit path
as an array of strings [].