### PR TITLE
Only check electron.app or electron.remote.app when needed.

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -18,33 +18,11 @@ const Helpers = require('./settings-helpers');
 const Observer = require('./settings-observer');
 
 /**
- * A reference to the Electron app. If this framework is required within a
- * renderer processes, we need to load the app via `remote`.
- *
- * @type {string}
- */
-const app = electron.app || electron.remote.app;
-
-/**
- * The Electron app's user data path.
- *
- * @type {string}
- */
-const userDataPath = app.getPath('userData');
-
-/**
  * The name of the settings file.
  *
  * @type {string}
  */
 const defaultSettingsFileName = 'Settings';
-
-/**
- * The absolute path to the settings file.
- *
- * @type {string}
- */
-const defaultSettingsFilePath = path.join(userDataPath, defaultSettingsFileName);
 
 /**
  * The electron-settings class.
@@ -56,14 +34,6 @@ class Settings extends EventEmitter {
 
   constructor() {
     super();
-
-    /**
-     * The absolute path to the default settings file on the disk.
-     *
-     * @type {string}
-     * @private
-     */
-    this._defaultSettingsFilePath = defaultSettingsFilePath;
 
     /**
      * The absolute path to the custom settings file on the disk.
@@ -100,9 +70,13 @@ class Settings extends EventEmitter {
    * @private
    */
   _getSettingsFilePath() {
-    return this._customSettingsFilePath ?
-      this._customSettingsFilePath :
-      this._defaultSettingsFilePath;
+    if (this._customSettingsFilePath) return this._customSettingsFilePath;
+
+    const app = electron.app || electron.remote.app;
+    const userDataPath = app.getPath('userData');
+    const defaultSettingsFilePath = path.join(userDataPath, defaultSettingsFileName);
+
+    return defaultSettingsFilePath;
   }
 
   /**


### PR DESCRIPTION
Fixes #106 and allows #94 via `setPath`.