### PR TITLE
fix: security issue with lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,17 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "atomically": "^2.0.1",
-        "lodash.get": "^4.4.2",
-        "lodash.has": "^4.5.2",
-        "lodash.set": "^4.3.2",
-        "lodash.unset": "^4.5.2",
+        "lodash": "^4.17.21",
         "mkdirp": "^1.0.4"
       },
       "devDependencies": {
-        "@types/lodash.get": "^4.4.7",
-        "@types/lodash.has": "^4.5.7",
-        "@types/lodash.set": "^4.3.7",
-        "@types/lodash.unset": "^4.5.7",
+        "@types/lodash": "^4.17.0",
         "@types/mkdirp": "^1.0.2",
         "@types/mocha": "^7.0.2",
         "@types/node": "^14.18.42",
@@ -306,46 +300,10 @@
       }
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.194",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.194.tgz",
-      "integrity": "sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
+      "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==",
       "dev": true
-    },
-    "node_modules/@types/lodash.get": {
-      "version": "4.4.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash.get/-/lodash.get-4.4.7.tgz",
-      "integrity": "sha512-af34Mj+KdDeuzsJBxc/XeTtOx0SZHZNLd+hdrn+PcKGQs0EG2TJTzQAOTCZTgDJCArahlCzLWSy8c2w59JRz7Q==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
-    "node_modules/@types/lodash.has": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash.has/-/lodash.has-4.5.7.tgz",
-      "integrity": "sha512-nfbAzRbsZBdzSAkL9iiLy4SQk89uuFcXBFwZ7pf6oZhBgPvNys8BY5Twp/w8XvZKGt1o6cAa85wX4QhqO3uQ7A==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
-    "node_modules/@types/lodash.set": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash.set/-/lodash.set-4.3.7.tgz",
-      "integrity": "sha512-bS5Wkg/nrT82YUfkNYPSccFrNZRL+irl7Yt4iM6OTSQ0VZJED2oUIVm15NkNtUAQ8SRhCe+axqERUV6MJgkeEg==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
-    "node_modules/@types/lodash.unset": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash.unset/-/lodash.unset-4.5.7.tgz",
-      "integrity": "sha512-/i371dATnLQ4tazwcX/n+rGk3M6RnMbA3lJKrKFjELicPExmZ1LcKtGfHBECuPS2TTl3yDuaFmWtmfACVuBBAQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
     },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",
@@ -3885,24 +3843,13 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==",
       "dev": true
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
-    },
-    "node_modules/lodash.has": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
-      "integrity": "sha512-rnYUdIo6xRCJnQmbVFEwcxF144erlD+M3YcJUVesflU9paQaE8p+fJDcIQrlMYbxoANFL+AB9hZrzSBBk5PL+g=="
     },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
@@ -3915,11 +3862,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
-    },
-    "node_modules/lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
     },
     "node_modules/lodash.template": {
       "version": "4.5.0",
@@ -3945,11 +3887,6 @@
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
       "dev": true
-    },
-    "node_modules/lodash.unset": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/lodash.unset/-/lodash.unset-4.5.2.tgz",
-      "integrity": "sha512-bwKX88k2JhCV9D1vtE8+naDKlLiGrSmf8zi/Y9ivFHwbmRfA8RxS/aVJ+sIht2XOwqoNr4xUPUkGZpc1sHFEKg=="
     },
     "node_modules/log-symbols": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -37,17 +37,11 @@
   },
   "dependencies": {
     "atomically": "^2.0.1",
-    "lodash.get": "^4.4.2",
-    "lodash.has": "^4.5.2",
-    "lodash.set": "^4.3.2",
-    "lodash.unset": "^4.5.2",
+    "lodash": "^4.17.21",
     "mkdirp": "^1.0.4"
   },
   "devDependencies": {
-    "@types/lodash.get": "^4.4.7",
-    "@types/lodash.has": "^4.5.7",
-    "@types/lodash.set": "^4.3.7",
-    "@types/lodash.unset": "^4.5.7",
+    "@types/lodash": "^4.17.0",
     "@types/mkdirp": "^1.0.2",
     "@types/mocha": "^7.0.2",
     "@types/node": "^14.18.42",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,10 +6,9 @@ import {
   writeFile as writeFileAtomic,
   writeFileSync as writeFileAtomicSync,
 } from 'atomically';
-import _get from 'lodash.get';
-import _has from 'lodash.has';
-import _set from 'lodash.set';
-import _unset from 'lodash.unset';
+import {
+  get as _get, has as _has, set as _set, unset as _unset,
+} from 'lodash';
 
 /**
  * At the basic level, a key path is the string equivalent


### PR DESCRIPTION
Switch from per method packages to main lodash package as there's a notice saying they won't be supported from v5 onward and they already don't seem to maintain them.
https://lodash.com/per-method-packages

Hopefully doesn't break anything.
Fix #179 